### PR TITLE
fix: resolve 9 golangci-lint issues (errcheck + staticcheck)

### DIFF
--- a/internal/domain/observability/observability.go
+++ b/internal/domain/observability/observability.go
@@ -194,11 +194,11 @@ func (s *ObservabilityService) evaluateCompleteness(ctx context.Context, operati
 	var coverageScore float64
 	
 	for _, op := range operations {
-		if op.OperationType == "save" {
+		switch op.OperationType {
+		case "save":
 			saveOps++
-		} else if op.OperationType == "get_related" {
+		case "get_related":
 			relatedOps++
-			// Coverage based on connections
 			if totalObservations > 0 {
 				coverageScore += float64(op.ResultCount) / float64(totalObservations)
 			}

--- a/internal/store/search/store.go
+++ b/internal/store/search/store.go
@@ -695,10 +695,7 @@ func (s *Store) pseudoRelevanceFeedback(ctx context.Context, originalQuery strin
 	}
 
 	// Build expanded query: original terms + top PRF terms
-	expandedTerms := make([]string, 0)
-	for _, t := range extractSearchTerms(originalQuery) {
-		expandedTerms = append(expandedTerms, t)
-	}
+	expandedTerms := append([]string{}, extractSearchTerms(originalQuery)...)
 	for _, tc := range ranked {
 		expandedTerms = append(expandedTerms, tc.term)
 	}

--- a/internal/store/sqlite/repositories.go
+++ b/internal/store/sqlite/repositories.go
@@ -66,13 +66,13 @@ func (r *MetricsRepository) GetTemporalMetrics(ctx context.Context, sessionID st
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	
+	defer func() { _ = rows.Close() }()
+
 	var metrics []*domain.Metrics
 	for rows.Next() {
 		metric := &domain.Metrics{}
 		var errorPtr sql.NullString
-		
+
 		err := rows.Scan(
 			&metric.ID,
 			&metric.SessionID,
@@ -91,14 +91,14 @@ func (r *MetricsRepository) GetTemporalMetrics(ctx context.Context, sessionID st
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if errorPtr.Valid {
 			metric.Error = errorPtr.String
 		}
-		
+
 		metrics = append(metrics, metric)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -106,18 +106,18 @@ func (r *MetricsRepository) GetTemporalMetrics(ctx context.Context, sessionID st
 func (r *MetricsRepository) GetByOperationType(ctx context.Context, operationType string, from, to time.Time) ([]*domain.Metrics, error) {
 	query := `
 		SELECT id, session_id, operation_type, duration_ms, result_count, success, error,
-		       memory_usage_bytes, timestamp, observation_count, edge_count, 
+		       memory_usage_bytes, timestamp, observation_count, edge_count,
 		       query_complexity, confidence_score
-		FROM metrics 
+		FROM metrics
 		WHERE operation_type = ? AND timestamp >= ? AND timestamp <= ?
 		ORDER BY timestamp DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, operationType, from, to)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var metrics []*domain.Metrics
 	for rows.Next() {
@@ -262,7 +262,7 @@ func (r *QualityMetricsRepository) GetBySession(ctx context.Context, sessionID s
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
@@ -305,7 +305,7 @@ func (r *QualityMetricsRepository) GetByType(ctx context.Context, evaluationType
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
@@ -348,7 +348,7 @@ func (r *QualityMetricsRepository) GetLatest(ctx context.Context, limit int) ([]
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
@@ -459,7 +459,7 @@ func (r *TemporalSnapshotRepository) GetBySnapshotKey(ctx context.Context, snaps
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {
@@ -502,7 +502,7 @@ func (r *TemporalSnapshotRepository) GetSnapshotsInRange(ctx context.Context, fr
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {
@@ -545,7 +545,7 @@ func (r *TemporalSnapshotRepository) GetByRootObservation(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {

--- a/internal/sync/transport.go
+++ b/internal/sync/transport.go
@@ -71,11 +71,11 @@ func (ft *FileTransport) WriteChunk(chunkID string, data []byte, _ ChunkEntry) e
 	if err != nil {
 		return fmt.Errorf("create chunk file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz := gzip.NewWriter(f)
 	if _, err := gz.Write(data); err != nil {
-		gz.Close()
+		_ = gz.Close()
 		return fmt.Errorf("write gzip data: %w", err)
 	}
 	if err := gz.Close(); err != nil {
@@ -91,13 +91,13 @@ func (ft *FileTransport) ReadChunk(chunkID string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open chunk %s: %w", chunkID, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
 		return nil, fmt.Errorf("gzip reader for chunk %s: %w", chunkID, err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	data, err := io.ReadAll(gz)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix 7 errcheck issues: `defer rows.Close()` -> `defer func() { _ = rows.Close() }()` in repositories.go and transport.go
- Fix 1 staticcheck QF1003: if/else chain -> tagged switch in observability.go
- Fix 1 staticcheck S1011: loop append -> `append(slice, other...)` in search store

## Test plan
- [x] `golangci-lint run ./...` -- 0 issues
- [x] `go test ./...` -- 27/27 packages passing