### PR TITLE
⚡ Bolt: Optimize strings.NewReplacer usage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,12 @@ type LifecycleConfig struct {
 	ArchiveCheckInterval string `yaml:"archive_check_interval" mapstructure:"archive_check_interval"`
 }
 
+var (
+	// envKeyReplacer is a thread-safe package-level replacer for environment variables.
+	// Initializing it globally avoids memory allocations on every load call.
+	envKeyReplacer = strings.NewReplacer(".", "_")
+)
+
 // Default configuration values
 var defaults = Config{
 	Server: ServerConfig{
@@ -183,7 +189,7 @@ func Load(configPath string) (*Config, error) {
 
 	// Enable environment variable override
 	v.SetEnvPrefix("CORTEX")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(envKeyReplacer)
 	v.AutomaticEnv()
 
 	// Read config file (optional - may not exist)
@@ -357,7 +363,7 @@ func LoadFromEnv() (*Config, error) {
 
 	// Enable environment variable override
 	v.SetEnvPrefix("CORTEX")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(envKeyReplacer)
 	v.AutomaticEnv()
 
 	// Unmarshal into config struct

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -233,20 +233,20 @@ type TemporalSnapshotRepository interface {
 
 // SystemMetrics represents aggregated system metrics.
 type SystemMetrics struct {
-	SessionID         string          `json:"session_id"`
-	TimeRange         *TimeRange      `json:"time_range"`
-	TotalOperations   int             `json:"total_operations"`
-	SuccessfulOps     int             `json:"successful_ops"`
-	FailedOps         int             `json:"failed_ops"`
-	AvgDurationMs     float64         `json:"avg_duration_ms"`
-	TotalMemoryUsage  int64           `json:"total_memory_usage"`
-	TotalObservations int             `json:"total_observations"`
-	TotalEdges        int             `json:"total_edges"`
-	AvgQueryComplexity float64         `json:"avg_query_complexity"`
-	AvgConfidence     float64         `json:"avg_confidence"`
-	EvaluatedAt       time.Time       `json:"evaluated_at"`
-	OperationBreakdown map[string]int  `json:"operation_breakdown"`
-	TopSlowOperations []string        `json:"top_slow_operations"`
+	SessionID          string         `json:"session_id"`
+	TimeRange          *TimeRange     `json:"time_range"`
+	TotalOperations    int            `json:"total_operations"`
+	SuccessfulOps      int            `json:"successful_ops"`
+	FailedOps          int            `json:"failed_ops"`
+	AvgDurationMs      float64        `json:"avg_duration_ms"`
+	TotalMemoryUsage   int64          `json:"total_memory_usage"`
+	TotalObservations  int            `json:"total_observations"`
+	TotalEdges         int            `json:"total_edges"`
+	AvgQueryComplexity float64        `json:"avg_query_complexity"`
+	AvgConfidence      float64        `json:"avg_confidence"`
+	EvaluatedAt        time.Time      `json:"evaluated_at"`
+	OperationBreakdown map[string]int `json:"operation_breakdown"`
+	TopSlowOperations  []string       `json:"top_slow_operations"`
 }
 
 // TimeRange represents a time range with start and end.
@@ -257,11 +257,11 @@ type TimeRange struct {
 
 // HealthCheck represents system health status.
 type HealthCheck struct {
-	Status           string    `json:"status"`           // healthy, degraded, critical
+	Status           string    `json:"status"` // healthy, degraded, critical
 	CheckTime        time.Time `json:"check_time"`
 	TotalOperations  int       `json:"total_operations"`
 	FailedOperations int       `json:"failed_operations"`
 	SlowOperations   int       `json:"slow_operations"`
-	AvgDurationMs   float64   `json:"avg_duration_ms"`
+	AvgDurationMs    float64   `json:"avg_duration_ms"`
 	Message          string    `json:"message"`
 }

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -44,20 +44,20 @@ type Edge struct {
 	ID           int64      `json:"id"`
 	FromObsID    int64      `json:"from_obs_id"`
 	ToObsID      int64      `json:"to_obs_id"`
-	RelationType string     `json:"relation_type"` // references, relates_to, follows
-	Weight       float64    `json:"weight"`        // Strength of relationship (0.0 to 10.0, default 1.0)
-	Confidence   float64    `json:"confidence"`    // Confidence in this relationship (0.0 to 1.0)
-	Source       string     `json:"source,omitempty"`    // Who/what created this edge
-	Reasoning    string     `json:"reasoning,omitempty"` // Why this relationship exists
-	ValidFrom    *time.Time `json:"valid_from,omitempty"`  // Temporal validity start
-	InvalidAt    *time.Time `json:"invalid_at,omitempty"`  // Temporal validity end (NULL = still valid)
+	RelationType string     `json:"relation_type"`        // references, relates_to, follows
+	Weight       float64    `json:"weight"`               // Strength of relationship (0.0 to 10.0, default 1.0)
+	Confidence   float64    `json:"confidence"`           // Confidence in this relationship (0.0 to 1.0)
+	Source       string     `json:"source,omitempty"`     // Who/what created this edge
+	Reasoning    string     `json:"reasoning,omitempty"`  // Why this relationship exists
+	ValidFrom    *time.Time `json:"valid_from,omitempty"` // Temporal validity start
+	InvalidAt    *time.Time `json:"invalid_at,omitempty"` // Temporal validity end (NULL = still valid)
 	CreatedAt    time.Time  `json:"created_at"`
-	
+
 	// Enhanced temporal graph fields
-	EvolutionID    *int64     `json:"evolution_id,omitempty"`     // Track edge evolution (NULL = original)
-	EvolutionType  string     `json:"evolution_type"`            // evolution types: original, modified, superseded, contradicted
-	FactState      string     `json:"fact_state"`                // fact states: current, historical, deprecated, superseded
-	ChangeReason   string     `json:"change_reason,omitempty"`   // Why the edge changed
+	EvolutionID   *int64 `json:"evolution_id,omitempty"`  // Track edge evolution (NULL = original)
+	EvolutionType string `json:"evolution_type"`          // evolution types: original, modified, superseded, contradicted
+	FactState     string `json:"fact_state"`              // fact states: current, historical, deprecated, superseded
+	ChangeReason  string `json:"change_reason,omitempty"` // Why the edge changed
 }
 
 // Prompt represents a user prompt captured during a session for replay
@@ -102,8 +102,8 @@ type SearchOptions struct {
 	Project     string  `json:"project,omitempty"`
 	Scope       string  `json:"scope,omitempty"`
 	Limit       int     `json:"limit,omitempty"`
-	FusionK     float64 `json:"fusion_k,omitempty"`      // RRF constant (default 60, lower = favor top ranks)
-	GraphExpand bool    `json:"graph_expand,omitempty"`   // Boost graph neighbors of top results
+	FusionK     float64 `json:"fusion_k,omitempty"`     // RRF constant (default 60, lower = favor top ranks)
+	GraphExpand bool    `json:"graph_expand,omitempty"` // Boost graph neighbors of top results
 }
 
 // SearchResult represents a search result with relevance ranking.
@@ -163,26 +163,26 @@ const (
 type EntityLink struct {
 	ID            int64     `json:"id"`
 	ObservationID int64     `json:"observation_id"`
-	EntityType    string    `json:"entity_type"`  // file, url, package, symbol, concept
+	EntityType    string    `json:"entity_type"` // file, url, package, symbol, concept
 	EntityValue   string    `json:"entity_value"`
 	CreatedAt     time.Time `json:"created_at"`
 }
 
 // Metrics represents observability metrics for memory system performance.
 type Metrics struct {
-	ID                 int64     `json:"id"`
-	SessionID          string    `json:"session_id"`
-	OperationType      string    `json:"operation_type"`   // save, search, relate, get_related, etc.
-	Duration           int64     `json:"duration_ms"`       // Operation duration in milliseconds
-	ResultCount        int       `json:"result_count"`      // Number of results returned
-	Success            bool      `json:"success"`           // Whether operation succeeded
-	Error              string    `json:"error,omitempty"`   // Error message if failed
-	MemoryUsage        int64     `json:"memory_usage_bytes"` // Memory usage in bytes
-	Timestamp          time.Time `json:"timestamp"`
-	ObservationCount   int       `json:"observation_count"` // Total observations in system
-	EdgeCount          int       `json:"edge_count"`       // Total edges in knowledge graph
-	QueryComplexity    float64   `json:"query_complexity"`  // Estimated query complexity (0.0-1.0)
-	ConfidenceScore    float64   `json:"confidence_score"`  // Average confidence score
+	ID               int64     `json:"id"`
+	SessionID        string    `json:"session_id"`
+	OperationType    string    `json:"operation_type"`     // save, search, relate, get_related, etc.
+	Duration         int64     `json:"duration_ms"`        // Operation duration in milliseconds
+	ResultCount      int       `json:"result_count"`       // Number of results returned
+	Success          bool      `json:"success"`            // Whether operation succeeded
+	Error            string    `json:"error,omitempty"`    // Error message if failed
+	MemoryUsage      int64     `json:"memory_usage_bytes"` // Memory usage in bytes
+	Timestamp        time.Time `json:"timestamp"`
+	ObservationCount int       `json:"observation_count"` // Total observations in system
+	EdgeCount        int       `json:"edge_count"`        // Total edges in knowledge graph
+	QueryComplexity  float64   `json:"query_complexity"`  // Estimated query complexity (0.0-1.0)
+	ConfidenceScore  float64   `json:"confidence_score"`  // Average confidence score
 }
 
 // AggregatedMetrics represents rolled-up performance metrics for a time range.
@@ -202,28 +202,28 @@ type AggregatedMetrics struct {
 
 // QualityMetrics represents memory quality evaluation metrics.
 type QualityMetrics struct {
-	ID                    int64     `json:"id"`
+	ID                   int64     `json:"id"`
 	SessionID            string    `json:"session_id"`
-	EvaluationType        string    `json:"evaluation_type"`   // relevance, completeness, consistency, temporal_accuracy
-	Score                 float64   `json:"score"`             // Score 0.0-1.0
-	TotalQueries          int       `json:"total_queries"`     // Number of queries evaluated
-	SuccessfulRetrievals   int       `json:"successful_retrievals"` // Number of successful retrievals
-	AverageLatency       float64   `json:"average_latency_ms"` // Average response time
-	AverageRelevance      float64   `json:"average_relevance"` // Average relevance score
-	TemporalAccuracy      float64   `json:"temporal_accuracy"` // How well temporal facts are preserved
-	KnowledgeCoverage     float64   `json:"knowledge_coverage"` // How much relevant knowledge is covered
-	EvaluatedAt           time.Time `json:"evaluated_at"`
+	EvaluationType       string    `json:"evaluation_type"`       // relevance, completeness, consistency, temporal_accuracy
+	Score                float64   `json:"score"`                 // Score 0.0-1.0
+	TotalQueries         int       `json:"total_queries"`         // Number of queries evaluated
+	SuccessfulRetrievals int       `json:"successful_retrievals"` // Number of successful retrievals
+	AverageLatency       float64   `json:"average_latency_ms"`    // Average response time
+	AverageRelevance     float64   `json:"average_relevance"`     // Average relevance score
+	TemporalAccuracy     float64   `json:"temporal_accuracy"`     // How well temporal facts are preserved
+	KnowledgeCoverage    float64   `json:"knowledge_coverage"`    // How much relevant knowledge is covered
+	EvaluatedAt          time.Time `json:"evaluated_at"`
 }
 
 // TemporalSnapshot represents a point-in-time snapshot of the knowledge graph.
 type TemporalSnapshot struct {
-	ID          int64     `json:"id"`
-	SnapshotKey string    `json:"snapshot_key"` // Unique identifier for this snapshot
-	Timestamp   time.Time `json:"timestamp"`
-	Description string    `json:"description,omitempty"`
-	ObservationCount int   `json:"observation_count"`
-	EdgeCount        int   `json:"edge_count"`
-	RootObservationID int64 `json:"root_observation_id,omitempty"` // Root observation for this snapshot
+	ID                int64     `json:"id"`
+	SnapshotKey       string    `json:"snapshot_key"` // Unique identifier for this snapshot
+	Timestamp         time.Time `json:"timestamp"`
+	Description       string    `json:"description,omitempty"`
+	ObservationCount  int       `json:"observation_count"`
+	EdgeCount         int       `json:"edge_count"`
+	RootObservationID int64     `json:"root_observation_id,omitempty"` // Root observation for this snapshot
 }
 
 // Entity types
@@ -243,18 +243,18 @@ const (
 
 // Evolution types for temporal graph edges
 const (
-	EvolutionOriginal   = "original"
-	EvolutionModified   = "modified"
-	EvolutionSuperseded = "superseded"
+	EvolutionOriginal     = "original"
+	EvolutionModified     = "modified"
+	EvolutionSuperseded   = "superseded"
 	EvolutionContradicted = "contradicted"
 )
 
 // Fact states for temporal graph edges
 const (
-	FactStateCurrent     = "current"
-	FactStateHistorical  = "historical"
-	FactStateDeprecated  = "deprecated"
-	FactStateSuperseded  = "superseded"
+	FactStateCurrent    = "current"
+	FactStateHistorical = "historical"
+	FactStateDeprecated = "deprecated"
+	FactStateSuperseded = "superseded"
 )
 
 // Additional temporal relation types.

--- a/internal/domain/observability/observability.go
+++ b/internal/domain/observability/observability.go
@@ -15,9 +15,9 @@ import (
 // ObservabilityService manages metrics collection and quality evaluation.
 type ObservabilityService struct {
 	metricsRepo     domain.MetricsRepository
-	qualityRepo    domain.QualityMetricsRepository
+	qualityRepo     domain.QualityMetricsRepository
 	temporalRepo    domain.TemporalSnapshotRepository
-	graphRepo      domain.GraphRepository
+	graphRepo       domain.GraphRepository
 	observationRepo domain.ObservationRepository
 }
 
@@ -31,9 +31,9 @@ func NewObservabilityService(
 ) *ObservabilityService {
 	return &ObservabilityService{
 		metricsRepo:     metricsRepo,
-		qualityRepo:    qualityRepo,
+		qualityRepo:     qualityRepo,
 		temporalRepo:    temporalRepo,
-		graphRepo:      graphRepo,
+		graphRepo:       graphRepo,
 		observationRepo: observationRepo,
 	}
 }
@@ -50,13 +50,13 @@ func (s *ObservabilityService) GetSystemMetrics(ctx context.Context, sessionID s
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Calculate aggregated metrics
 	var totalDuration, totalMemory int64
 	var successCount, totalCount int
 	var totalObservations, totalEdges int
 	var totalComplexity, totalConfidence float64
-	
+
 	for _, op := range operations {
 		totalDuration += op.Duration
 		totalMemory += op.MemoryUsage
@@ -69,54 +69,54 @@ func (s *ObservabilityService) GetSystemMetrics(ctx context.Context, sessionID s
 		totalComplexity += op.QueryComplexity
 		totalConfidence += op.ConfidenceScore
 	}
-	
+
 	avgDuration := float64(0)
 	if totalCount > 0 {
 		avgDuration = float64(totalDuration) / float64(totalCount)
 	}
-	
+
 	avgComplexity := float64(0)
 	if totalCount > 0 {
 		avgComplexity = totalComplexity / float64(totalCount)
 	}
-	
+
 	avgConfidence := float64(0)
 	if totalCount > 0 {
 		avgConfidence = totalConfidence / float64(totalCount)
 	}
-	
+
 	systemMetrics := &domain.SystemMetrics{
-		SessionID:         sessionID,
-		TimeRange:         &domain.TimeRange{From: from, To: to},
-		TotalOperations:   totalCount,
-		SuccessfulOps:     successCount,
-		FailedOps:         totalCount - successCount,
-		AvgDurationMs:     avgDuration,
-		TotalMemoryUsage:  totalMemory,
-		TotalObservations: totalObservations,
-		TotalEdges:        totalEdges,
+		SessionID:          sessionID,
+		TimeRange:          &domain.TimeRange{From: from, To: to},
+		TotalOperations:    totalCount,
+		SuccessfulOps:      successCount,
+		FailedOps:          totalCount - successCount,
+		AvgDurationMs:      avgDuration,
+		TotalMemoryUsage:   totalMemory,
+		TotalObservations:  totalObservations,
+		TotalEdges:         totalEdges,
 		AvgQueryComplexity: avgComplexity,
-		AvgConfidence:     avgConfidence,
-		EvaluatedAt:       time.Now(),
+		AvgConfidence:      avgConfidence,
+		EvaluatedAt:        time.Now(),
 	}
-	
+
 	return systemMetrics, nil
 }
 
 // EvaluateMemoryQuality evaluates the quality of the memory system.
 func (s *ObservabilityService) EvaluateMemoryQuality(ctx context.Context, sessionID string, evalType string) (*domain.QualityMetrics, error) {
 	now := time.Now()
-	
+
 	// Get recent operations
 	from := now.Add(-24 * time.Hour) // Evaluate last 24 hours
 	operations, err := s.metricsRepo.GetTemporalMetrics(ctx, sessionID, from, now)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Calculate quality scores based on evaluation type
 	var quality *domain.QualityMetrics
-	
+
 	switch evalType {
 	case "relevance":
 		quality = s.evaluateRelevance(ctx, operations, from, now)
@@ -131,16 +131,16 @@ func (s *ObservabilityService) EvaluateMemoryQuality(ctx context.Context, sessio
 	default:
 		return nil, fmt.Errorf("unsupported evaluation type: %s", evalType)
 	}
-	
+
 	quality.SessionID = sessionID
 	quality.EvaluationType = evalType
 	quality.EvaluatedAt = now
-	
+
 	// Save evaluation results
 	if err := s.qualityRepo.CreateQualityMetric(ctx, quality); err != nil {
 		return nil, err
 	}
-	
+
 	return quality, nil
 }
 
@@ -148,7 +148,7 @@ func (s *ObservabilityService) EvaluateMemoryQuality(ctx context.Context, sessio
 func (s *ObservabilityService) evaluateRelevance(ctx context.Context, operations []*domain.Metrics, from, to time.Time) *domain.QualityMetrics {
 	var totalQueries, successfulRetrievals int
 	var totalLatency, totalRelevance float64
-	
+
 	for _, op := range operations {
 		if op.OperationType == "search" {
 			totalQueries++
@@ -159,28 +159,28 @@ func (s *ObservabilityService) evaluateRelevance(ctx context.Context, operations
 			}
 		}
 	}
-	
+
 	avgLatency := float64(0)
 	if successfulRetrievals > 0 {
 		avgLatency = totalLatency / float64(successfulRetrievals)
 	}
-	
+
 	avgRelevance := float64(0)
 	if successfulRetrievals > 0 {
 		avgRelevance = totalRelevance / float64(successfulRetrievals)
 	}
-	
+
 	score := float64(0)
 	if totalQueries > 0 {
 		score = float64(successfulRetrievals) / float64(totalQueries)
 	}
 
 	return &domain.QualityMetrics{
-		Score:             score,
-		TotalQueries:      totalQueries,
+		Score:                score,
+		TotalQueries:         totalQueries,
 		SuccessfulRetrievals: successfulRetrievals,
-		AverageLatency:    avgLatency,
-		AverageRelevance:  avgRelevance,
+		AverageLatency:       avgLatency,
+		AverageRelevance:     avgRelevance,
 	}
 }
 
@@ -189,10 +189,10 @@ func (s *ObservabilityService) evaluateCompleteness(ctx context.Context, operati
 	// Get total system state
 	totalObservations, _ := s.observationRepo.CountAll(ctx)
 	_, _ = s.graphRepo.CountAllEdges(ctx)
-	
+
 	var saveOps, relatedOps int
 	var coverageScore float64
-	
+
 	for _, op := range operations {
 		switch op.OperationType {
 		case "save":
@@ -204,20 +204,20 @@ func (s *ObservabilityService) evaluateCompleteness(ctx context.Context, operati
 			}
 		}
 	}
-	
+
 	// Calculate coverage score
 	finalScore := float64(0)
 	if saveOps > 0 {
 		finalScore = coverageScore / float64(saveOps)
 	}
-	
+
 	return &domain.QualityMetrics{
-		Score:        finalScore,
-		TotalQueries: saveOps + relatedOps,
+		Score:                finalScore,
+		TotalQueries:         saveOps + relatedOps,
 		SuccessfulRetrievals: relatedOps,
-		AverageLatency: 0, // Not applicable for completeness
-		AverageRelevance: finalScore,
-		KnowledgeCoverage: finalScore,
+		AverageLatency:       0, // Not applicable for completeness
+		AverageRelevance:     finalScore,
+		KnowledgeCoverage:    finalScore,
 	}
 }
 
@@ -226,18 +226,18 @@ func (s *ObservabilityService) evaluateConsistency(ctx context.Context, operatio
 	// Check for contradictions and inconsistencies
 	contradictions, _ := s.graphRepo.GetContradictions(ctx, from, to)
 	totalEdges, _ := s.graphRepo.CountAllEdges(ctx)
-	
+
 	var consistencyScore float64
 	if totalEdges > 0 {
 		consistencyScore = 1.0 - (float64(len(contradictions)) / float64(totalEdges))
 	}
-	
+
 	return &domain.QualityMetrics{
-		Score:             consistencyScore,
-		TotalQueries:      len(operations),
+		Score:                consistencyScore,
+		TotalQueries:         len(operations),
 		SuccessfulRetrievals: len(operations),
-		AverageLatency:    0, // Not applicable
-		AverageRelevance:  consistencyScore,
+		AverageLatency:       0, // Not applicable
+		AverageRelevance:     consistencyScore,
 	}
 }
 
@@ -248,7 +248,7 @@ func (s *ObservabilityService) evaluateTemporalAccuracy(ctx context.Context, ope
 	if err != nil {
 		return &domain.QualityMetrics{Score: 0.5} // Default moderate score
 	}
-	
+
 	var accuracyScore float64
 	if len(snapshots) > 0 {
 		// Calculate accuracy based on snapshot consistency
@@ -256,7 +256,7 @@ func (s *ObservabilityService) evaluateTemporalAccuracy(ctx context.Context, ope
 			// Compare with current state
 			currentEdges, _ := s.graphRepo.CountEdgesByObservation(ctx, snapshot.RootObservationID)
 			expectedEdges := snapshot.EdgeCount
-			
+
 			if expectedEdges > 0 {
 				snapshotAccuracy := float64(currentEdges) / float64(expectedEdges)
 				accuracyScore += snapshotAccuracy
@@ -264,13 +264,13 @@ func (s *ObservabilityService) evaluateTemporalAccuracy(ctx context.Context, ope
 		}
 		accuracyScore /= float64(len(snapshots))
 	}
-	
+
 	return &domain.QualityMetrics{
-		Score:              accuracyScore,
-		TotalQueries:       len(snapshots),
+		Score:                accuracyScore,
+		TotalQueries:         len(snapshots),
 		SuccessfulRetrievals: len(snapshots),
-		AverageLatency:     0, // Not applicable
-		TemporalAccuracy:   accuracyScore,
+		AverageLatency:       0, // Not applicable
+		TemporalAccuracy:     accuracyScore,
 	}
 }
 
@@ -281,37 +281,37 @@ func (s *ObservabilityService) evaluateOverallQuality(ctx context.Context, opera
 	completeness := s.evaluateCompleteness(ctx, operations, from, to)
 	consistency := s.evaluateConsistency(ctx, operations, from, to)
 	temporal := s.evaluateTemporalAccuracy(ctx, operations, from, to)
-	
+
 	// Weighted average (adjustable weights based on importance)
-	finalScore := (relevance.Score * 0.3) + (completeness.Score * 0.25) + 
+	finalScore := (relevance.Score * 0.3) + (completeness.Score * 0.25) +
 		(consistency.Score * 0.25) + (temporal.Score * 0.2)
-	
+
 	return &domain.QualityMetrics{
-		Score:              finalScore,
-		TotalQueries:       len(operations),
+		Score:                finalScore,
+		TotalQueries:         len(operations),
 		SuccessfulRetrievals: len(operations),
-		AverageLatency:     (relevance.AverageLatency + temporal.AverageLatency) / 2,
-		AverageRelevance:   (relevance.AverageRelevance + completeness.AverageRelevance) / 2,
-		TemporalAccuracy:   temporal.TemporalAccuracy,
-		KnowledgeCoverage: completeness.KnowledgeCoverage,
+		AverageLatency:       (relevance.AverageLatency + temporal.AverageLatency) / 2,
+		AverageRelevance:     (relevance.AverageRelevance + completeness.AverageRelevance) / 2,
+		TemporalAccuracy:     temporal.TemporalAccuracy,
+		KnowledgeCoverage:    completeness.KnowledgeCoverage,
 	}
 }
 
 // GetHealthCheck provides system health status.
 func (s *ObservabilityService) GetHealthCheck(ctx context.Context) (*domain.HealthCheck, error) {
 	now := time.Now()
-	
+
 	// Get recent metrics for health assessment
 	from := now.Add(-1 * time.Hour) // Last hour
 	operations, err := s.metricsRepo.GetTemporalMetrics(ctx, "", from, now)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Calculate health metrics
 	var failedOps, slowOps int
 	var avgDuration float64
-	
+
 	for _, op := range operations {
 		if !op.Success {
 			failedOps++
@@ -321,11 +321,11 @@ func (s *ObservabilityService) GetHealthCheck(ctx context.Context) (*domain.Heal
 		}
 		avgDuration += float64(op.Duration)
 	}
-	
+
 	if len(operations) > 0 {
 		avgDuration /= float64(len(operations))
 	}
-	
+
 	// Determine health status
 	status := "healthy"
 	totalOps := len(operations)
@@ -335,17 +335,16 @@ func (s *ObservabilityService) GetHealthCheck(ctx context.Context) (*domain.Heal
 	if float64(slowOps) > float64(totalOps)*0.3 { // > 30% slow operations
 		status = "degraded"
 	}
-	
+
 	health := &domain.HealthCheck{
 		Status:           status,
 		CheckTime:        now,
 		TotalOperations:  len(operations),
 		FailedOperations: failedOps,
 		SlowOperations:   slowOps,
-		AvgDurationMs:   avgDuration,
-		Message:         fmt.Sprintf("System %s with %d operations in last hour", status, len(operations)),
+		AvgDurationMs:    avgDuration,
+		Message:          fmt.Sprintf("System %s with %d operations in last hour", status, len(operations)),
 	}
-	
+
 	return health, nil
 }
-

--- a/internal/domain/observability/observability_test.go
+++ b/internal/domain/observability/observability_test.go
@@ -12,7 +12,7 @@ import (
 // --- Mock implementations ---
 
 type mockMetricsRepo struct {
-	CreateMetricFn      func(ctx context.Context, metric *domain.Metrics) error
+	CreateMetricFn       func(ctx context.Context, metric *domain.Metrics) error
 	GetTemporalMetricsFn func(ctx context.Context, sessionID string, from, to time.Time) ([]*domain.Metrics, error)
 }
 
@@ -89,8 +89,8 @@ func (m *mockTemporalSnapshotRepo) GetByRootObservation(ctx context.Context, roo
 }
 
 type mockGraphRepo struct {
-	CountAllEdgesFn          func(ctx context.Context) (int, error)
-	GetContradictionsFn      func(ctx context.Context, from, to time.Time) ([]*domain.Edge, error)
+	CountAllEdgesFn           func(ctx context.Context) (int, error)
+	GetContradictionsFn       func(ctx context.Context, from, to time.Time) ([]*domain.Edge, error)
 	CountEdgesByObservationFn func(ctx context.Context, obsID int64) (int, error)
 }
 
@@ -143,7 +143,7 @@ func (m *mockObservationRepo) GetByTopicKey(ctx context.Context, project, topicK
 	return nil, nil
 }
 func (m *mockObservationRepo) Update(ctx context.Context, obs *domain.Observation) error { return nil }
-func (m *mockObservationRepo) Delete(ctx context.Context, id int64) error               { return nil }
+func (m *mockObservationRepo) Delete(ctx context.Context, id int64) error                { return nil }
 func (m *mockObservationRepo) List(ctx context.Context, filter domain.ObservationFilter) ([]*domain.Observation, error) {
 	return nil, nil
 }

--- a/internal/domain/scoring/scoring_test.go
+++ b/internal/domain/scoring/scoring_test.go
@@ -18,15 +18,15 @@ type mockRepository struct {
 	topScores    []*domain.ImportanceScore
 
 	// Error injection
-	getScoreErr          error
-	getObservationErr    error
-	getIncomingEdgeErr   error
-	setScoreErr          error
-	getAllScoresErr       error
-	getTopByScoreErr     error
-	recordAccessErr      error
-	updateScoreErr       error
-	getTopErr            error
+	getScoreErr        error
+	getObservationErr  error
+	getIncomingEdgeErr error
+	setScoreErr        error
+	getAllScoresErr    error
+	getTopByScoreErr   error
+	recordAccessErr    error
+	updateScoreErr     error
+	getTopErr          error
 
 	// Track calls
 	setScoreCalls []setScoreCall
@@ -134,71 +134,71 @@ func TestCalculateScore_Success(t *testing.T) {
 	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name        string
-		obsType     string
-		createdAt   time.Time
-		accessCount int
+		name         string
+		obsType      string
+		createdAt    time.Time
+		accessCount  int
 		lastAccessed time.Time
-		edgeCount   int
-		wantMin     float64
-		wantMax     float64
-		desc        string
+		edgeCount    int
+		wantMin      float64
+		wantMax      float64
+		desc         string
 	}{
 		{
-			name:        "decision type, recent access, edges",
-			obsType:     domain.TypeDecision,
-			createdAt:   now.Add(-2 * 24 * time.Hour), // 2 days old
-			accessCount: 5,
+			name:         "decision type, recent access, edges",
+			obsType:      domain.TypeDecision,
+			createdAt:    now.Add(-2 * 24 * time.Hour), // 2 days old
+			accessCount:  5,
 			lastAccessed: now.Add(-1 * time.Hour), // accessed 1 hour ago (within recency window)
-			edgeCount:   3,
+			edgeCount:    3,
 			// base(0.5) + access(min(5*0.1,1.0)=0.5) + recency(0.5) + edges(min(3*0.2,1.0)=0.6) + type(0.5) - age(2*0.01=0.02) = 2.58
 			wantMin: 2.5,
 			wantMax: 2.7,
 			desc:    "score=0.5+0.5+0.5+0.6+0.5-0.02=2.58",
 		},
 		{
-			name:        "bugfix type, no recent access, no edges",
-			obsType:     domain.TypeBugfix,
-			createdAt:   now.Add(-30 * 24 * time.Hour), // 30 days old
-			accessCount: 0,
+			name:         "bugfix type, no recent access, no edges",
+			obsType:      domain.TypeBugfix,
+			createdAt:    now.Add(-30 * 24 * time.Hour), // 30 days old
+			accessCount:  0,
 			lastAccessed: now.Add(-48 * time.Hour), // accessed 2 days ago (outside recency window)
-			edgeCount:   0,
+			edgeCount:    0,
 			// base(0.5) + access(0) + recency(0) + edges(0) + type(0.3) - age(min(30*0.01,0.5)=0.3) = 0.5
 			wantMin: 0.45,
 			wantMax: 0.55,
 			desc:    "score=0.5+0+0+0+0.3-0.3=0.5",
 		},
 		{
-			name:        "manual type (no type bonus), max access bonus",
-			obsType:     domain.TypeManual,
-			createdAt:   now.Add(-1 * 24 * time.Hour), // 1 day old
-			accessCount: 15,                             // over max access bonus
+			name:         "manual type (no type bonus), max access bonus",
+			obsType:      domain.TypeManual,
+			createdAt:    now.Add(-1 * 24 * time.Hour), // 1 day old
+			accessCount:  15,                           // over max access bonus
 			lastAccessed: now.Add(-30 * time.Minute),
-			edgeCount:   0,
+			edgeCount:    0,
 			// base(0.5) + access(min(15*0.1,1.0)=1.0) + recency(0.5) + edges(0) + type(0) - age(1*0.01=0.01) = 1.99
 			wantMin: 1.9,
 			wantMax: 2.1,
 			desc:    "score=0.5+1.0+0.5+0+0-0.01=1.99",
 		},
 		{
-			name:        "max edge bonus capped",
-			obsType:     domain.TypePattern,
-			createdAt:   now,
-			accessCount: 0,
+			name:         "max edge bonus capped",
+			obsType:      domain.TypePattern,
+			createdAt:    now,
+			accessCount:  0,
 			lastAccessed: now,
-			edgeCount:   10, // would be 10*0.2=2.0, capped to 1.0
+			edgeCount:    10, // would be 10*0.2=2.0, capped to 1.0
 			// base(0.5) + access(0) + recency(0.5) + edges(1.0) + type(0.2) - age(0) = 2.2
 			wantMin: 2.1,
 			wantMax: 2.3,
 			desc:    "edge bonus capped at 1.0",
 		},
 		{
-			name:        "very old observation, age penalty capped",
-			obsType:     domain.TypeConfig,
-			createdAt:   now.Add(-365 * 24 * time.Hour), // 365 days old
-			accessCount: 0,
+			name:         "very old observation, age penalty capped",
+			obsType:      domain.TypeConfig,
+			createdAt:    now.Add(-365 * 24 * time.Hour), // 365 days old
+			accessCount:  0,
 			lastAccessed: now.Add(-365 * 24 * time.Hour),
-			edgeCount:   0,
+			edgeCount:    0,
 			// base(0.5) + access(0) + recency(0) + edges(0) + type(0.1) - age(min(365*0.01,0.5)=0.5) = 0.1
 			wantMin: 0.05,
 			wantMax: 0.15,

--- a/internal/domain/session/session.go
+++ b/internal/domain/session/session.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/google/uuid"
+	"github.com/lleontor705/cortex/internal/domain"
 )
 
 // Service provides session management operations.

--- a/internal/domain/temporal/temporal.go
+++ b/internal/domain/temporal/temporal.go
@@ -16,10 +16,10 @@ import (
 
 // TemporalService provides enhanced temporal graph functionality.
 type TemporalService struct {
-	graphRepo    domain.GraphRepository
+	graphRepo       domain.GraphRepository
 	observationRepo domain.ObservationRepository
-	snapshotRepo  domain.TemporalSnapshotRepository
-	metricsRepo   domain.MetricsRepository
+	snapshotRepo    domain.TemporalSnapshotRepository
+	metricsRepo     domain.MetricsRepository
 }
 
 // NewTemporalService creates a new temporal graph service.
@@ -30,37 +30,37 @@ func NewTemporalService(
 	metricsRepo domain.MetricsRepository,
 ) *TemporalService {
 	return &TemporalService{
-		graphRepo:      graphRepo,
+		graphRepo:       graphRepo,
 		observationRepo: observationRepo,
-		snapshotRepo:   snapshotRepo,
-		metricsRepo:    metricsRepo,
+		snapshotRepo:    snapshotRepo,
+		metricsRepo:     metricsRepo,
 	}
 }
 
 // CreateTemporalEdge creates an edge with temporal validity and evolution tracking.
 func (s *TemporalService) CreateTemporalEdge(ctx context.Context, edge *domain.Edge) error {
 	now := time.Now()
-	
+
 	// Set default temporal validity if not specified
 	if edge.ValidFrom == nil {
 		edge.ValidFrom = &now
 	}
-	
+
 	// Validate temporal constraints
 	if edge.InvalidAt != nil && edge.ValidFrom != nil && edge.InvalidAt.Before(*edge.ValidFrom) {
 		return fmt.Errorf("invalid_at must be after valid_from")
 	}
-	
+
 	// Set initial evolution state
 	if edge.EvolutionType == "" {
 		edge.EvolutionType = domain.EvolutionOriginal
 	}
-	
+
 	// Set initial fact state
 	if edge.FactState == "" {
 		edge.FactState = domain.FactStateCurrent
 	}
-	
+
 	return s.graphRepo.CreateEdge(ctx, edge)
 }
 
@@ -70,14 +70,14 @@ func (s *TemporalService) GetTemporalEdges(ctx context.Context, obsID int64, at 
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var validEdges []*domain.Edge
 	for _, edge := range allEdges {
 		if s.isValidAtTime(edge, at) {
 			validEdges = append(validEdges, edge)
 		}
 	}
-	
+
 	return validEdges, nil
 }
 
@@ -88,13 +88,13 @@ func (s *TemporalService) GetEvolutionPath(ctx context.Context, edgeID int64) ([
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Get all edges that share the same evolution chain
 	allEdges, err := s.graphRepo.GetEvolutionChain(ctx, edge.FromObsID, edge.ToObsID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Filter and return evolution path in chronological order
 	var evolutionPath []*domain.Edge
 	for _, e := range allEdges {
@@ -102,97 +102,97 @@ func (s *TemporalService) GetEvolutionPath(ctx context.Context, edgeID int64) ([
 			evolutionPath = append(evolutionPath, e)
 		}
 	}
-	
+
 	return evolutionPath, nil
 }
 
 // GetCurrentFactState determines the current state of facts related to an observation.
 func (s *TemporalService) GetCurrentFactState(ctx context.Context, obsID int64) (map[string]*domain.Edge, error) {
 	now := time.Now()
-	
+
 	allEdges, err := s.graphRepo.GetEdgesForObservation(ctx, obsID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	currentFacts := make(map[string]*domain.Edge)
 	for _, edge := range allEdges {
 		if s.isValidAtTime(edge, now) && edge.FactState == domain.FactStateCurrent {
 			currentFacts[fmt.Sprintf("%s_%d", edge.RelationType, edge.ToObsID)] = edge
 		}
 	}
-	
+
 	return currentFacts, nil
 }
 
 // HandleTemporalContradiction handles contradictions between facts with temporal reasoning.
 func (s *TemporalService) HandleTemporalContradiction(ctx context.Context, factA, factB *domain.Edge) (*domain.Edge, error) {
 	now := time.Now()
-	
+
 	// Determine which fact is more current/reliable
 	olderFact, newerFact := s.getOlderFact(factA, factB)
-	
+
 	// Mark the older fact as contradicted
 	contradictionEdge := &domain.Edge{
-		FromObsID:    olderFact.FromObsID,
-		ToObsID:      olderFact.ToObsID,
-		RelationType: domain.RelationContradicts,
-		Weight:       olderFact.Weight,
-		Confidence:   0.9, // High confidence in contradiction
-		Source:       "system",
-		Reasoning:    fmt.Sprintf("Contradicted by fact %d at %s", newerFact.ID, now.Format(time.RFC3339)),
-		ValidFrom:    &now,
+		FromObsID:     olderFact.FromObsID,
+		ToObsID:       olderFact.ToObsID,
+		RelationType:  domain.RelationContradicts,
+		Weight:        olderFact.Weight,
+		Confidence:    0.9, // High confidence in contradiction
+		Source:        "system",
+		Reasoning:     fmt.Sprintf("Contradicted by fact %d at %s", newerFact.ID, now.Format(time.RFC3339)),
+		ValidFrom:     &now,
 		EvolutionType: domain.EvolutionContradicted,
-		FactState:    domain.FactStateDeprecated,
+		FactState:     domain.FactStateDeprecated,
 	}
-	
+
 	// Create the contradiction edge
 	if err := s.graphRepo.CreateEdge(ctx, contradictionEdge); err != nil {
 		return nil, err
 	}
-	
+
 	// Mark the original fact as superseded
 	now = time.Now()
 	supersededEdge := &domain.Edge{
-		FromObsID:    newerFact.FromObsID,
-		ToObsID:      newerFact.ToObsID,
-		RelationType: newerFact.RelationType,
-		Weight:       newerFact.Weight,
-		Confidence:   newerFact.Confidence,
-		Source:       "system",
-		Reasoning:    fmt.Sprintf("Superseded due to contradiction at %s", now.Format(time.RFC3339)),
-		ValidFrom:    &now,
+		FromObsID:     newerFact.FromObsID,
+		ToObsID:       newerFact.ToObsID,
+		RelationType:  newerFact.RelationType,
+		Weight:        newerFact.Weight,
+		Confidence:    newerFact.Confidence,
+		Source:        "system",
+		Reasoning:     fmt.Sprintf("Superseded due to contradiction at %s", now.Format(time.RFC3339)),
+		ValidFrom:     &now,
 		EvolutionType: domain.EvolutionSuperseded,
-		FactState:    domain.FactStateCurrent,
+		FactState:     domain.FactStateCurrent,
 	}
-	
+
 	return supersededEdge, s.graphRepo.UpdateEdge(ctx, supersededEdge)
 }
 
 // CreateTemporalSnapshot creates a point-in-time snapshot of the knowledge graph.
 func (s *TemporalService) CreateTemporalSnapshot(ctx context.Context, snapshotKey string, rootObsID int64, description string) (*domain.TemporalSnapshot, error) {
 	now := time.Now()
-	
+
 	// Count observations and edges related to root observation
 	obsCount, err := s.observationRepo.CountByRoot(ctx, rootObsID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	edgeCount, err := s.graphRepo.CountEdgesByObservation(ctx, rootObsID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	snapshot := &domain.TemporalSnapshot{
-		SnapshotKey:     snapshotKey,
-		Timestamp:       now,
-		Description:     description,
-		ObservationCount: obsCount,
-		EdgeCount:       edgeCount,
+		SnapshotKey:       snapshotKey,
+		Timestamp:         now,
+		Description:       description,
+		ObservationCount:  obsCount,
+		EdgeCount:         edgeCount,
 		RootObservationID: rootObsID,
 	}
-	
+
 	if err := s.snapshotRepo.CreateSnapshot(ctx, snapshot); err != nil {
 		return nil, err
 	}
@@ -206,25 +206,25 @@ func (s *TemporalService) GetTemporalRelevant(ctx context.Context, obsID int64, 
 	if _, err := s.GetTemporalEdges(ctx, obsID, at); err != nil {
 		return nil, err
 	}
-	
+
 	// Build knowledge graph from temporal edges
 	relatedObs := make([]*domain.Observation, 0)
 	visited := make(map[int64]bool)
-	
+
 	var traverse func(currentID int64, currentDepth int)
 	traverse = func(currentID int64, currentDepth int) {
 		if currentDepth > depth || visited[currentID] {
 			return
 		}
-		
+
 		visited[currentID] = true
-		
+
 		// Get observation
 		obs, err := s.observationRepo.GetByID(ctx, currentID)
 		if err == nil {
 			relatedObs = append(relatedObs, obs)
 		}
-		
+
 		// Get temporal edges from this observation
 		edges, err := s.GetTemporalEdges(ctx, currentID, at)
 		if err == nil {
@@ -233,10 +233,10 @@ func (s *TemporalService) GetTemporalRelevant(ctx context.Context, obsID int64, 
 			}
 		}
 	}
-	
+
 	// Start traversal from the root observation
 	traverse(obsID, 0)
-	
+
 	return relatedObs, nil
 }
 
@@ -246,12 +246,12 @@ func (s *TemporalService) isValidAtTime(edge *domain.Edge, at time.Time) bool {
 	if edge.ValidFrom != nil && at.Before(*edge.ValidFrom) {
 		return false
 	}
-	
+
 	// Check if edge is still valid (no invalidation time)
 	if edge.InvalidAt == nil {
 		return true
 	}
-	
+
 	return !at.After(*edge.InvalidAt)
 }
 

--- a/internal/domain/temporal/temporal_test.go
+++ b/internal/domain/temporal/temporal_test.go
@@ -14,12 +14,12 @@ import (
 
 // mockGraphRepo implements only the GraphRepository methods that temporal.go calls.
 type mockGraphRepo struct {
-	createEdgeFunc             func(ctx context.Context, edge *domain.Edge) error
-	getEdgesForObservationFunc func(ctx context.Context, obsID int64) ([]*domain.Edge, error)
-	getEdgeFunc                func(ctx context.Context, id int64) (*domain.Edge, error)
-	getEvolutionChainFunc      func(ctx context.Context, fromObsID, toObsID int64) ([]*domain.Edge, error)
+	createEdgeFunc              func(ctx context.Context, edge *domain.Edge) error
+	getEdgesForObservationFunc  func(ctx context.Context, obsID int64) ([]*domain.Edge, error)
+	getEdgeFunc                 func(ctx context.Context, id int64) (*domain.Edge, error)
+	getEvolutionChainFunc       func(ctx context.Context, fromObsID, toObsID int64) ([]*domain.Edge, error)
 	countEdgesByObservationFunc func(ctx context.Context, obsID int64) (int, error)
-	updateEdgeFunc             func(ctx context.Context, edge *domain.Edge) error
+	updateEdgeFunc              func(ctx context.Context, edge *domain.Edge) error
 }
 
 func (m *mockGraphRepo) CreateEdge(ctx context.Context, edge *domain.Edge) error {
@@ -86,7 +86,7 @@ type mockObservationRepo struct {
 	getByIDFunc     func(ctx context.Context, id int64) (*domain.Observation, error)
 }
 
-func (m *mockObservationRepo) Save(ctx context.Context, obs *domain.Observation) error   { return nil }
+func (m *mockObservationRepo) Save(ctx context.Context, obs *domain.Observation) error { return nil }
 func (m *mockObservationRepo) GetByID(ctx context.Context, id int64) (*domain.Observation, error) {
 	if m.getByIDFunc != nil {
 		return m.getByIDFunc(ctx, id)
@@ -101,7 +101,7 @@ func (m *mockObservationRepo) Delete(ctx context.Context, id int64) error       
 func (m *mockObservationRepo) List(ctx context.Context, filter domain.ObservationFilter) ([]*domain.Observation, error) {
 	return nil, nil
 }
-func (m *mockObservationRepo) CountAll(ctx context.Context) (int, error)   { return 0, nil }
+func (m *mockObservationRepo) CountAll(ctx context.Context) (int, error) { return 0, nil }
 func (m *mockObservationRepo) CountByRoot(ctx context.Context, rootObsID int64) (int, error) {
 	if m.countByRootFunc != nil {
 		return m.countByRootFunc(ctx, rootObsID)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -175,4 +175,3 @@ func textResult(format string, args ...any) (*mcp.CallToolResult, error) {
 func errorResult(format string, args ...any) (*mcp.CallToolResult, error) {
 	return mcp.NewToolResultError(fmt.Sprintf(format, args...)), nil
 }
-

--- a/internal/mcp/temporal_tools.go
+++ b/internal/mcp/temporal_tools.go
@@ -93,18 +93,18 @@ func NewTemporalToolsHandler(
 // CreateTemporalEdge creates an edge with temporal validity and evolution tracking.
 func (h *TemporalToolsHandler) CreateTemporalEdge(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
-		FromObsID    int64   `json:"from_obs_id"`
-		ToObsID      int64   `json:"to_obs_id"`
-		RelationType string  `json:"relation_type"`
-		Weight       float64 `json:"weight"`
-		Confidence   float64 `json:"confidence"`
-		Source       string  `json:"source"`
-		Reasoning    string  `json:"reasoning"`
-		ValidFrom    string  `json:"valid_from"`    // ISO format string
-		InvalidAt    string  `json:"invalid_at"`    // ISO format string, optional
-		EvolutionType string `json:"evolution_type"`
-		FactState     string `json:"fact_state"`
-		ChangeReason  string `json:"change_reason"`
+		FromObsID     int64   `json:"from_obs_id"`
+		ToObsID       int64   `json:"to_obs_id"`
+		RelationType  string  `json:"relation_type"`
+		Weight        float64 `json:"weight"`
+		Confidence    float64 `json:"confidence"`
+		Source        string  `json:"source"`
+		Reasoning     string  `json:"reasoning"`
+		ValidFrom     string  `json:"valid_from"` // ISO format string
+		InvalidAt     string  `json:"invalid_at"` // ISO format string, optional
+		EvolutionType string  `json:"evolution_type"`
+		FactState     string  `json:"fact_state"`
+		ChangeReason  string  `json:"change_reason"`
 	}
 
 	if err := req.BindArguments(&params); err != nil {
@@ -130,15 +130,15 @@ func (h *TemporalToolsHandler) CreateTemporalEdge(ctx context.Context, req *prot
 	}
 
 	edge := &domain.Edge{
-		FromObsID:    params.FromObsID,
-		ToObsID:      params.ToObsID,
-		RelationType: params.RelationType,
-		Weight:       params.Weight,
-		Confidence:   params.Confidence,
-		Source:       params.Source,
-		Reasoning:    params.Reasoning,
-		ValidFrom:    validFrom,
-		InvalidAt:    invalidAt,
+		FromObsID:     params.FromObsID,
+		ToObsID:       params.ToObsID,
+		RelationType:  params.RelationType,
+		Weight:        params.Weight,
+		Confidence:    params.Confidence,
+		Source:        params.Source,
+		Reasoning:     params.Reasoning,
+		ValidFrom:     validFrom,
+		InvalidAt:     invalidAt,
 		EvolutionType: params.EvolutionType,
 		FactState:     params.FactState,
 		ChangeReason:  params.ChangeReason,
@@ -186,8 +186,8 @@ func (h *TemporalToolsHandler) GetTemporalEdges(ctx context.Context, req *protoc
 func (h *TemporalToolsHandler) GetTemporalRelevant(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
 		ObservationID int64  `json:"observation_id"`
-		At            string `json:"at"`           // ISO format string
-		Depth         int    `json:"depth"`        // Traversal depth
+		At            string `json:"at"`    // ISO format string
+		Depth         int    `json:"depth"` // Traversal depth
 	}
 
 	if err := req.BindArguments(&params); err != nil {
@@ -217,9 +217,9 @@ func (h *TemporalToolsHandler) GetTemporalRelevant(ctx context.Context, req *pro
 // CreateTemporalSnapshot creates a point-in-time snapshot of the knowledge graph.
 func (h *TemporalToolsHandler) CreateTemporalSnapshot(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
-		SnapshotKey     string `json:"snapshot_key"`
+		SnapshotKey       string `json:"snapshot_key"`
 		RootObservationID int64  `json:"root_observation_id"`
-		Description     string `json:"description"`
+		Description       string `json:"description"`
 	}
 
 	if err := req.BindArguments(&params); err != nil {
@@ -243,18 +243,18 @@ func (h *TemporalToolsHandler) CreateTemporalSnapshot(ctx context.Context, req *
 // RecordOperation records an operation with performance metrics.
 func (h *TemporalToolsHandler) RecordOperation(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
-		SessionID          string    `json:"session_id"`
-		OperationType      string    `json:"operation_type"`
-		Duration           int64     `json:"duration_ms"`
-		ResultCount        int       `json:"result_count"`
-		Success            bool      `json:"success"`
-		Error              string    `json:"error"`
-		MemoryUsage        int64     `json:"memory_usage_bytes"`
-		Timestamp          string    `json:"timestamp"`  // ISO format
-		ObservationCount   int       `json:"observation_count"`
-		EdgeCount          int       `json:"edge_count"`
-		QueryComplexity    float64   `json:"query_complexity"`
-		ConfidenceScore    float64   `json:"confidence_score"`
+		SessionID        string  `json:"session_id"`
+		OperationType    string  `json:"operation_type"`
+		Duration         int64   `json:"duration_ms"`
+		ResultCount      int     `json:"result_count"`
+		Success          bool    `json:"success"`
+		Error            string  `json:"error"`
+		MemoryUsage      int64   `json:"memory_usage_bytes"`
+		Timestamp        string  `json:"timestamp"` // ISO format
+		ObservationCount int     `json:"observation_count"`
+		EdgeCount        int     `json:"edge_count"`
+		QueryComplexity  float64 `json:"query_complexity"`
+		ConfidenceScore  float64 `json:"confidence_score"`
 	}
 
 	if err := req.BindArguments(&params); err != nil {
@@ -268,18 +268,18 @@ func (h *TemporalToolsHandler) RecordOperation(ctx context.Context, req *protoco
 	}
 
 	metric := &domain.Metrics{
-		SessionID:         params.SessionID,
-		OperationType:     params.OperationType,
-		Duration:          params.Duration,
-		ResultCount:       params.ResultCount,
-		Success:           params.Success,
-		Error:             params.Error,
-		MemoryUsage:       params.MemoryUsage,
-		Timestamp:         timestamp,
-		ObservationCount:  params.ObservationCount,
-		EdgeCount:         params.EdgeCount,
-		QueryComplexity:   params.QueryComplexity,
-		ConfidenceScore:   params.ConfidenceScore,
+		SessionID:        params.SessionID,
+		OperationType:    params.OperationType,
+		Duration:         params.Duration,
+		ResultCount:      params.ResultCount,
+		Success:          params.Success,
+		Error:            params.Error,
+		MemoryUsage:      params.MemoryUsage,
+		Timestamp:        timestamp,
+		ObservationCount: params.ObservationCount,
+		EdgeCount:        params.EdgeCount,
+		QueryComplexity:  params.QueryComplexity,
+		ConfidenceScore:  params.ConfidenceScore,
 	}
 
 	if err := h.observabilityService.RecordOperation(ctx, metric); err != nil {
@@ -292,7 +292,7 @@ func (h *TemporalToolsHandler) RecordOperation(ctx context.Context, req *protoco
 // EvaluateMemoryQuality evaluates the quality of the memory system.
 func (h *TemporalToolsHandler) EvaluateMemoryQuality(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
-		SessionID    string `json:"session_id"`
+		SessionID      string `json:"session_id"`
 		EvaluationType string `json:"evaluation_type"` // relevance, completeness, consistency, temporal_accuracy, overall
 	}
 
@@ -318,8 +318,8 @@ func (h *TemporalToolsHandler) EvaluateMemoryQuality(ctx context.Context, req *p
 func (h *TemporalToolsHandler) GetSystemMetrics(ctx context.Context, req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var params struct {
 		SessionID string `json:"session_id"`
-		From      string `json:"from"`  // ISO format
-		To        string `json:"to"`    // ISO format
+		From      string `json:"from"` // ISO format
+		To        string `json:"to"`   // ISO format
 	}
 
 	if err := req.BindArguments(&params); err != nil {

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -818,4 +818,3 @@ func BenchmarkStatus(b *testing.B) {
 		_, _ = m.Status(ctx)
 	}
 }
-

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -332,4 +332,3 @@ func jsonString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
-

--- a/internal/store/scoring/store_test.go
+++ b/internal/store/scoring/store_test.go
@@ -381,7 +381,7 @@ func TestGetIncomingEdgeCount(t *testing.T) {
 
 	// Create edges: obs1->obs2, obs3->obs2
 	db.Exec(`INSERT INTO edges (from_obs_id, to_obs_id, relation_type, weight) VALUES (?, ?, 'references', 1.0)`, obs1, obs2) //nolint:errcheck
-	db.Exec(`INSERT INTO edges (from_obs_id, to_obs_id, relation_type, weight) VALUES (?, ?, 'relates_to', 1.0)`, obs3, obs2)  //nolint:errcheck
+	db.Exec(`INSERT INTO edges (from_obs_id, to_obs_id, relation_type, weight) VALUES (?, ?, 'relates_to', 1.0)`, obs3, obs2) //nolint:errcheck
 
 	t.Run("with edges", func(t *testing.T) {
 		count, err := store.GetIncomingEdgeCount(ctx, obs2)

--- a/internal/store/search/store.go
+++ b/internal/store/search/store.go
@@ -19,6 +19,24 @@ import (
 	"github.com/lleontor705/cortex/internal/domain"
 )
 
+var (
+	// ftsReplacer is a thread-safe package-level replacer for sanitizing FTS queries.
+	// Initializing it globally avoids memory allocations on every search call.
+	ftsReplacer = strings.NewReplacer(
+		"*", "",
+		"^", "",
+		"~", "",
+		"+", "",
+		"-", " ",
+		"(", "",
+		")", "",
+	)
+
+	// extractTermsReplacer is a thread-safe package-level replacer for extracting search terms.
+	// Initializing it globally avoids memory allocations on every extraction call.
+	extractTermsReplacer = strings.NewReplacer("*", "", "^", "", "~", "", "+", "", "-", " ", "(", "", ")", "", `"`, "", "'", "")
+)
+
 // Store implements the SQLite search store.
 // It provides FTS5-based full-text search with advanced features.
 type Store struct {
@@ -317,16 +335,7 @@ func sanitizeFTS(query string) string {
 
 	// Remove FTS5 special operators that could cause syntax errors
 	// These characters have special meaning in FTS5: * ^ ~ + - ( )
-	replacer := strings.NewReplacer(
-		"*", "",
-		"^", "",
-		"~", "",
-		"+", "",
-		"-", " ",
-		"(", "",
-		")", "",
-	)
-	query = replacer.Replace(query)
+	query = ftsReplacer.Replace(query)
 
 	// Escape double quotes by replacing them with single quotes
 	query = strings.ReplaceAll(query, `"`, `'`)
@@ -897,8 +906,7 @@ func collectIDs(sets ...[]*domain.SearchResult) []int64 {
 // extractSearchTerms extracts clean search terms from a query string.
 func extractSearchTerms(query string) []string {
 	query = strings.ToLower(strings.TrimSpace(query))
-	replacer := strings.NewReplacer("*", "", "^", "", "~", "", "+", "", "-", " ", "(", "", ")", "", `"`, "", "'", "")
-	query = replacer.Replace(query)
+	query = extractTermsReplacer.Replace(query)
 	terms := strings.Fields(query)
 	// Filter out very common stop words
 	var filtered []string

--- a/internal/store/sqlite/memory_store.go
+++ b/internal/store/sqlite/memory_store.go
@@ -1165,11 +1165,11 @@ func (s *Store) RecordSyncedChunk(ctx context.Context, chunkID string) error {
 
 // ExportData holds all data for sync export.
 type ExportData struct {
-	Version      string               `json:"version"`
-	ExportedAt   string               `json:"exported_at"`
-	Sessions     []*domain.Session    `json:"sessions"`
+	Version      string                `json:"version"`
+	ExportedAt   string                `json:"exported_at"`
+	Sessions     []*domain.Session     `json:"sessions"`
 	Observations []*domain.Observation `json:"observations"`
-	Prompts      []*domain.Prompt     `json:"prompts"`
+	Prompts      []*domain.Prompt      `json:"prompts"`
 }
 
 // ExportAll exports all sessions, observations, and prompts for sync.

--- a/internal/store/sqlite/repositories.go
+++ b/internal/store/sqlite/repositories.go
@@ -32,7 +32,7 @@ func (r *MetricsRepository) CreateMetric(ctx context.Context, metric *domain.Met
 		 timestamp, observation_count, edge_count, query_complexity, confidence_score)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	
+
 	_, err := r.db.ExecContext(ctx, query,
 		metric.SessionID,
 		metric.OperationType,
@@ -47,7 +47,7 @@ func (r *MetricsRepository) CreateMetric(ctx context.Context, metric *domain.Met
 		metric.QueryComplexity,
 		metric.ConfidenceScore,
 	)
-	
+
 	return err
 }
 
@@ -61,7 +61,7 @@ func (r *MetricsRepository) GetTemporalMetrics(ctx context.Context, sessionID st
 		WHERE session_id = ? AND timestamp >= ? AND timestamp <= ?
 		ORDER BY timestamp DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, sessionID, from, to)
 	if err != nil {
 		return nil, err
@@ -118,12 +118,12 @@ func (r *MetricsRepository) GetByOperationType(ctx context.Context, operationTyp
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var metrics []*domain.Metrics
 	for rows.Next() {
 		metric := &domain.Metrics{}
 		var errorPtr sql.NullString
-		
+
 		err := rows.Scan(
 			&metric.ID,
 			&metric.SessionID,
@@ -142,14 +142,14 @@ func (r *MetricsRepository) GetByOperationType(ctx context.Context, operationTyp
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if errorPtr.Valid {
 			metric.Error = errorPtr.String
 		}
-		
+
 		metrics = append(metrics, metric)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -169,12 +169,12 @@ func (r *MetricsRepository) GetAggregatedMetrics(ctx context.Context, from, to t
 		FROM metrics 
 		WHERE timestamp >= ? AND timestamp <= ?
 	`
-	
+
 	row := r.db.QueryRowContext(ctx, query, from, to)
-	
+
 	agg := &domain.AggregatedMetrics{}
 	var avgDuration, avgObsCount, avgEdgeCount, avgComplexity, avgConfidence sql.NullFloat64
-	
+
 	err := row.Scan(
 		&agg.TotalOperations,
 		&agg.SuccessfulOps,
@@ -189,7 +189,7 @@ func (r *MetricsRepository) GetAggregatedMetrics(ctx context.Context, from, to t
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if avgDuration.Valid {
 		agg.AvgDurationMs = avgDuration.Float64
 	}
@@ -205,10 +205,10 @@ func (r *MetricsRepository) GetAggregatedMetrics(ctx context.Context, from, to t
 	if avgConfidence.Valid {
 		agg.AvgConfidenceScore = avgConfidence.Float64
 	}
-	
+
 	agg.TimeRange = &domain.TimeRange{From: from, To: to}
 	agg.EvaluatedAt = time.Now()
-	
+
 	return agg, nil
 }
 
@@ -230,7 +230,7 @@ func (r *QualityMetricsRepository) CreateQualityMetric(ctx context.Context, qual
 		 average_latency_ms, average_relevance, temporal_accuracy, knowledge_coverage, evaluated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	
+
 	_, err := r.db.ExecContext(ctx, query,
 		quality.SessionID,
 		quality.EvaluationType,
@@ -243,7 +243,7 @@ func (r *QualityMetricsRepository) CreateQualityMetric(ctx context.Context, qual
 		quality.KnowledgeCoverage,
 		quality.EvaluatedAt,
 	)
-	
+
 	return err
 }
 
@@ -257,17 +257,17 @@ func (r *QualityMetricsRepository) GetBySession(ctx context.Context, sessionID s
 		ORDER BY evaluated_at DESC
 		LIMIT ?
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, sessionID, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
 		metric := &domain.QualityMetrics{}
-		
+
 		err := rows.Scan(
 			&metric.ID,
 			&metric.SessionID,
@@ -284,10 +284,10 @@ func (r *QualityMetricsRepository) GetBySession(ctx context.Context, sessionID s
 		if err != nil {
 			return nil, err
 		}
-		
+
 		metrics = append(metrics, metric)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -300,17 +300,17 @@ func (r *QualityMetricsRepository) GetByType(ctx context.Context, evaluationType
 		WHERE evaluation_type = ? AND evaluated_at >= ? AND evaluated_at <= ?
 		ORDER BY evaluated_at DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, evaluationType, from, to)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
 		metric := &domain.QualityMetrics{}
-		
+
 		err := rows.Scan(
 			&metric.ID,
 			&metric.SessionID,
@@ -327,10 +327,10 @@ func (r *QualityMetricsRepository) GetByType(ctx context.Context, evaluationType
 		if err != nil {
 			return nil, err
 		}
-		
+
 		metrics = append(metrics, metric)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -343,17 +343,17 @@ func (r *QualityMetricsRepository) GetLatest(ctx context.Context, limit int) ([]
 		ORDER BY evaluated_at DESC
 		LIMIT ?
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var metrics []*domain.QualityMetrics
 	for rows.Next() {
 		metric := &domain.QualityMetrics{}
-		
+
 		err := rows.Scan(
 			&metric.ID,
 			&metric.SessionID,
@@ -370,10 +370,10 @@ func (r *QualityMetricsRepository) GetLatest(ctx context.Context, limit int) ([]
 		if err != nil {
 			return nil, err
 		}
-		
+
 		metrics = append(metrics, metric)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -394,7 +394,7 @@ func (r *TemporalSnapshotRepository) CreateSnapshot(ctx context.Context, snapsho
 		(snapshot_key, timestamp, description, observation_count, edge_count, root_observation_id)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`
-	
+
 	result, err := r.db.ExecContext(ctx, query,
 		snapshot.SnapshotKey,
 		snapshot.Timestamp,
@@ -406,10 +406,10 @@ func (r *TemporalSnapshotRepository) CreateSnapshot(ctx context.Context, snapsho
 	if err != nil {
 		return err
 	}
-	
+
 	id, _ := result.LastInsertId()
 	snapshot.ID = id
-	
+
 	return nil
 }
 
@@ -420,12 +420,12 @@ func (r *TemporalSnapshotRepository) GetByID(ctx context.Context, id int64) (*do
 		FROM temporal_snapshots 
 		WHERE id = ?
 	`
-	
+
 	row := r.db.QueryRowContext(ctx, query, id)
-	
+
 	snapshot := &domain.TemporalSnapshot{}
 	var rootObsID sql.NullInt64
-	
+
 	err := row.Scan(
 		&snapshot.ID,
 		&snapshot.SnapshotKey,
@@ -438,11 +438,11 @@ func (r *TemporalSnapshotRepository) GetByID(ctx context.Context, id int64) (*do
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if rootObsID.Valid {
 		snapshot.RootObservationID = rootObsID.Int64
 	}
-	
+
 	return snapshot, nil
 }
 
@@ -454,18 +454,18 @@ func (r *TemporalSnapshotRepository) GetBySnapshotKey(ctx context.Context, snaps
 		WHERE snapshot_key = ?
 		ORDER BY timestamp DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, snapshotKey)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {
 		snapshot := &domain.TemporalSnapshot{}
 		var rootObsID sql.NullInt64
-		
+
 		err := rows.Scan(
 			&snapshot.ID,
 			&snapshot.SnapshotKey,
@@ -478,14 +478,14 @@ func (r *TemporalSnapshotRepository) GetBySnapshotKey(ctx context.Context, snaps
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if rootObsID.Valid {
 			snapshot.RootObservationID = rootObsID.Int64
 		}
-		
+
 		snapshots = append(snapshots, snapshot)
 	}
-	
+
 	return snapshots, nil
 }
 
@@ -497,18 +497,18 @@ func (r *TemporalSnapshotRepository) GetSnapshotsInRange(ctx context.Context, fr
 		WHERE timestamp >= ? AND timestamp <= ?
 		ORDER BY timestamp DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, from, to)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {
 		snapshot := &domain.TemporalSnapshot{}
 		var rootObsID sql.NullInt64
-		
+
 		err := rows.Scan(
 			&snapshot.ID,
 			&snapshot.SnapshotKey,
@@ -521,14 +521,14 @@ func (r *TemporalSnapshotRepository) GetSnapshotsInRange(ctx context.Context, fr
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if rootObsID.Valid {
 			snapshot.RootObservationID = rootObsID.Int64
 		}
-		
+
 		snapshots = append(snapshots, snapshot)
 	}
-	
+
 	return snapshots, nil
 }
 
@@ -540,18 +540,18 @@ func (r *TemporalSnapshotRepository) GetByRootObservation(ctx context.Context, r
 		WHERE root_observation_id = ?
 		ORDER BY timestamp DESC
 	`
-	
+
 	rows, err := r.db.QueryContext(ctx, query, rootObsID)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	
+
 	var snapshots []*domain.TemporalSnapshot
 	for rows.Next() {
 		snapshot := &domain.TemporalSnapshot{}
 		var rootObsID sql.NullInt64
-		
+
 		err := rows.Scan(
 			&snapshot.ID,
 			&snapshot.SnapshotKey,
@@ -564,13 +564,13 @@ func (r *TemporalSnapshotRepository) GetByRootObservation(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if rootObsID.Valid {
 			snapshot.RootObservationID = rootObsID.Int64
 		}
-		
+
 		snapshots = append(snapshots, snapshot)
 	}
-	
+
 	return snapshots, nil
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -91,4 +91,3 @@ func truncate(s string, max int) string {
 	}
 	return string(runes[:max]) + "..."
 }
-


### PR DESCRIPTION
💡 **What:** Moved `strings.NewReplacer` instances in `internal/store/search/store.go` and `internal/config/config.go` to be package-level global variables.
🎯 **Why:** `strings.NewReplacer` compiles its replacement rules and allocates memory upon creation. Instantiating it inside frequently called functions like search query sanitization or configuration loading adds unnecessary per-call overhead and memory allocations. Making them global variables initializes them once, leveraging their thread-safety.
📊 **Impact:** Reduces memory allocations per operation during searches and config loading.
🔬 **Measurement:** Verified via `go test -bench . -benchmem ./internal/store/search`, observing a reduction in allocations per operation in the benchmark results.

---
*PR created automatically by Jules for task [3768207027002730527](https://jules.google.com/task/3768207027002730527) started by @lleontor705*