### PR TITLE
feat: TUI embedding config screen + Ollama auto-launcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.46.0
 	github.com/spf13/viper v1.21.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.47.0
 )
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,11 +8,14 @@ import (
 	"runtime"
 	"time"
 
+	"log"
+
 	"github.com/lleontor705/cortex/internal/config"
 	"github.com/lleontor705/cortex/internal/database"
 	"github.com/lleontor705/cortex/internal/domain/lifecycle"
 	"github.com/lleontor705/cortex/internal/embedding"
 	"github.com/lleontor705/cortex/internal/migration"
+	"github.com/lleontor705/cortex/internal/ollama"
 	"github.com/lleontor705/cortex/internal/store/bundle"
 	entitystore "github.com/lleontor705/cortex/internal/store/entity"
 	graphstore "github.com/lleontor705/cortex/internal/store/graph"
@@ -93,9 +96,19 @@ func Open(ctx context.Context, opts Options) (*App, error) {
 	// Wire graph store into search for temporal-aware graph expansion
 	stores.Search.Graph = stores.Graph
 
+	// Auto-start Ollama if configured
+	if cfg.Search.EmbeddingProvider == "ollama" && cfg.Search.OllamaAutoStart {
+		mgr := ollama.NewManager(cfg.Search.EmbeddingBaseURL)
+		if err := mgr.EnsureRunning(context.Background()); err != nil {
+			log.Printf("warning: could not auto-start ollama: %v", err)
+		}
+	}
+
 	// Initialize embedding service if configured
 	embCfg := embedding.Config{
 		Provider: cfg.Search.EmbeddingProvider,
+		Model:    cfg.Search.EmbeddingModel,
+		BaseURL:  cfg.Search.EmbeddingBaseURL,
 	}
 	stores.Embeddings = embedding.New(embCfg)
 
@@ -122,6 +135,33 @@ func Open(ctx context.Context, opts Options) (*App, error) {
 	}
 
 	return a, nil
+}
+
+// ReloadConfig re-reads the configuration from disk and reinitializes
+// the embedding service. Useful after manual edits to cortex.yaml.
+func (a *App) ReloadConfig() error {
+	cfg, err := config.Load("")
+	if err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+	a.Config = cfg
+
+	// Auto-start Ollama if configured
+	if cfg.Search.EmbeddingProvider == "ollama" && cfg.Search.OllamaAutoStart {
+		mgr := ollama.NewManager(cfg.Search.EmbeddingBaseURL)
+		if err := mgr.EnsureRunning(context.Background()); err != nil {
+			log.Printf("warning: could not auto-start ollama on reload: %v", err)
+		}
+	}
+
+	// Reinitialize embedding service
+	a.Stores.Embeddings = embedding.New(embedding.Config{
+		Provider: cfg.Search.EmbeddingProvider,
+		Model:    cfg.Search.EmbeddingModel,
+		BaseURL:  cfg.Search.EmbeddingBaseURL,
+	})
+
+	return nil
 }
 
 // Close releases resources held by the application.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/lleontor705/cortex/internal/app"
 	"github.com/lleontor705/cortex/internal/domain"
+	"github.com/lleontor705/cortex/internal/ollama"
 	cortexhttp "github.com/lleontor705/cortex/internal/http"
 	"github.com/lleontor705/cortex/internal/mcp"
 	"github.com/lleontor705/cortex/internal/migration"
@@ -568,6 +569,8 @@ func runTUI(stdout, stderr io.Writer) int {
 		Graph:        a.Stores.Graph,
 		Scoring:      a.Stores.Scoring,
 		Entities:     a.Stores.Entities,
+		App:          a,
+		Config:       a.Config,
 		Version:      Version,
 	}
 
@@ -1091,6 +1094,36 @@ func runReindex(args []string, stdout, stderr io.Writer) int {
 	if a.Stores.Vectors == nil || !a.Stores.Vectors.IsAvailable() {
 		writef(stderr, "cortex: vector store not available.\nBuild with: go build -tags cortex_vectors ./cmd/cortex\n")
 		return 1
+	}
+
+	// Auto-start Ollama if configured
+	if a.Config.Search.EmbeddingProvider == "ollama" {
+		ctx := context.Background()
+		mgr := ollama.NewManager(a.Config.Search.EmbeddingBaseURL)
+		if !mgr.IsRunning(ctx) {
+			writeln(stdout, "Starting Ollama...")
+			if err := mgr.EnsureRunning(ctx); err != nil {
+				writef(stderr, "cortex: failed to start ollama: %v\n", err)
+				return 1
+			}
+			writeln(stdout, "Ollama is ready.")
+		}
+		// Check if model exists, pull if needed
+		model := a.Config.Search.EmbeddingModel
+		if model == "" {
+			model = "nomic-embed-text"
+		}
+		has, _ := mgr.HasModel(ctx, model)
+		if !has {
+			writef(stdout, "Pulling model %s...\n", model)
+			if err := mgr.PullModel(ctx, model, func(p string) {
+				writef(stdout, "  %s\n", p)
+			}); err != nil {
+				writef(stderr, "cortex: failed to pull model: %v\n", err)
+				return 1
+			}
+			writef(stdout, "Model %s pulled successfully.\n", model)
+		}
 	}
 
 	project := ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // CortexDir returns the centralized data directory (~/.cortex/).
@@ -91,7 +92,10 @@ type SearchConfig struct {
 	FTS5              bool    `yaml:"fts5" mapstructure:"fts5"`
 	Vector            bool    `yaml:"vector" mapstructure:"vector"`
 	FusionK           float64 `yaml:"fusion_k" mapstructure:"fusion_k"`
-	EmbeddingProvider string  `yaml:"embedding_provider" mapstructure:"embedding_provider"` // "openai", "none" (default)
+	EmbeddingProvider string `yaml:"embedding_provider" mapstructure:"embedding_provider"` // "ollama", "openai", "none" (default)
+	EmbeddingModel    string `yaml:"embedding_model" mapstructure:"embedding_model"`       // Model name override (e.g. "qwen3-embedding:8b")
+	EmbeddingBaseURL  string `yaml:"embedding_base_url" mapstructure:"embedding_base_url"` // Ollama base URL override (default: http://localhost:11434)
+	OllamaAutoStart   bool   `yaml:"ollama_auto_start" mapstructure:"ollama_auto_start"`   // Auto-start Ollama when configured as provider
 }
 
 // MemoryConfig holds memory management configuration
@@ -188,12 +192,13 @@ func Load(configPath string) (*Config, error) {
 	v.AutomaticEnv()
 
 	// Read config file (optional - may not exist)
+	configNotFound := false
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			// Config file was found but another error was produced
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
-		// Config file not found; ignore and use defaults + env vars
+		configNotFound = true
 	}
 
 	// Unmarshal into config struct
@@ -205,6 +210,11 @@ func Load(configPath string) (*Config, error) {
 	// Validate configuration
 	if err := validate(&cfg); err != nil {
 		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// Create default config file if none was found and no explicit path was given
+	if configNotFound && configPath == "" {
+		_ = ensureDefaultConfig(&cfg)
 	}
 
 	return &cfg, nil
@@ -399,4 +409,45 @@ func (c *Config) String() string {
 		"Config{Server: %+v, Database: %+v, MCP: %+v, HTTP: %+v, Logging: %+v, Search: %+v, Memory: %+v, Lifecycle: %+v}",
 		c.Server, c.Database, c.MCP, c.HTTP, c.Logging, c.Search, c.Memory, c.Lifecycle,
 	)
+}
+
+// ensureDefaultConfig creates ~/.cortex/cortex.yaml with default values
+// if it does not already exist. Errors are intentionally ignored (best-effort).
+func ensureDefaultConfig(cfg *Config) error {
+	path := filepath.Join(CortexDir(), "cortex.yaml")
+	if _, err := os.Stat(path); err == nil {
+		return nil // file already exists
+	}
+	return Save(cfg, path)
+}
+
+// Save writes the configuration to the specified path.
+// If path is empty, writes to ~/.cortex/cortex.yaml.
+// The write is atomic: data goes to a .tmp file first, then renamed.
+func Save(cfg *Config, path string) error {
+	if path == "" {
+		path = filepath.Join(CortexDir(), "cortex.yaml")
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename config: %w", err)
+	}
+
+	return nil
 }

--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -1,0 +1,189 @@
+// Package ollama manages the Ollama process lifecycle for Cortex.
+//
+// It provides health checking, automatic startup, model detection,
+// and model pulling — all used by the TUI, CLI, and app initialization.
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Manager handles checking, starting, and provisioning Ollama.
+type Manager struct {
+	baseURL     string
+	startedByUs bool
+	cmd         *exec.Cmd
+}
+
+// NewManager creates a new Ollama manager.
+// If baseURL is empty, defaults to http://localhost:11434.
+func NewManager(baseURL string) *Manager {
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	}
+	return &Manager{baseURL: baseURL}
+}
+
+// IsRunning checks whether Ollama is responding at the configured URL.
+func (m *Manager) IsRunning(ctx context.Context) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, "GET", m.baseURL+"/api/tags", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// Start launches `ollama serve` as a background process.
+// It does not wait for readiness — use WaitReady after Start.
+func (m *Manager) Start(ctx context.Context) error {
+	binary := "ollama"
+	if runtime.GOOS == "windows" {
+		binary = "ollama.exe"
+	}
+
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return fmt.Errorf("ollama binary not found in PATH: %w", err)
+	}
+
+	m.cmd = exec.CommandContext(ctx, path, "serve")
+	detachProcess(m.cmd)
+
+	if err := m.cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start ollama serve: %w", err)
+	}
+
+	m.startedByUs = true
+	return nil
+}
+
+// WaitReady polls the health endpoint until Ollama responds or timeout expires.
+func (m *Manager) WaitReady(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if m.IsRunning(ctx) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("ollama did not become ready within %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// tagsResponse represents the Ollama /api/tags JSON response.
+type tagsResponse struct {
+	Models []struct {
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+// HasModel checks if a specific model is available in Ollama.
+func (m *Manager) HasModel(ctx context.Context, model string) (bool, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, "GET", m.baseURL+"/api/tags", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("ollama not reachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("ollama returned status %d", resp.StatusCode)
+	}
+
+	var tags tagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return false, fmt.Errorf("failed to decode tags: %w", err)
+	}
+
+	// Normalize: "qwen3-embedding:8b" matches "qwen3-embedding:8b" or "qwen3-embedding:8b-..."
+	// Also handle bare names without tag (e.g., "nomic-embed-text" matches "nomic-embed-text:latest")
+	for _, t := range tags.Models {
+		if t.Name == model || strings.HasPrefix(t.Name, model+":") || strings.TrimSuffix(t.Name, ":latest") == model {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// PullModel runs `ollama pull <model>` and reports progress via the callback.
+// The progressFn is called with status strings; it may be nil.
+func (m *Manager) PullModel(ctx context.Context, model string, progressFn func(string)) error {
+	binary := "ollama"
+	if runtime.GOOS == "windows" {
+		binary = "ollama.exe"
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "pull", model)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start ollama pull: %w", err)
+	}
+
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := stdout.Read(buf)
+		if n > 0 && progressFn != nil {
+			progressFn(strings.TrimSpace(string(buf[:n])))
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("ollama pull failed: %w", err)
+	}
+	return nil
+}
+
+// EnsureRunning checks if Ollama is running, starts it if not, and waits for readiness.
+func (m *Manager) EnsureRunning(ctx context.Context) error {
+	if m.IsRunning(ctx) {
+		return nil
+	}
+	if err := m.Start(ctx); err != nil {
+		return err
+	}
+	return m.WaitReady(ctx, 30*time.Second)
+}
+
+// StartedByUs returns true if this manager started the Ollama process.
+func (m *Manager) StartedByUs() bool {
+	return m.startedByUs
+}
+
+// BaseURL returns the configured Ollama base URL.
+func (m *Manager) BaseURL() string {
+	return m.baseURL
+}

--- a/internal/ollama/ollama_test.go
+++ b/internal/ollama/ollama_test.go
@@ -1,0 +1,130 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIsRunning_WhenOllamaResponds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tags" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(tagsResponse{})
+		}
+	}))
+	defer srv.Close()
+
+	mgr := NewManager(srv.URL)
+	ctx := context.Background()
+
+	if !mgr.IsRunning(ctx) {
+		t.Fatal("expected IsRunning to return true")
+	}
+}
+
+func TestIsRunning_WhenOllamaDown(t *testing.T) {
+	mgr := NewManager("http://localhost:19999")
+	ctx := context.Background()
+
+	if mgr.IsRunning(ctx) {
+		t.Fatal("expected IsRunning to return false for unreachable server")
+	}
+}
+
+func TestHasModel_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(tagsResponse{
+			Models: []struct {
+				Name string `json:"name"`
+			}{
+				{Name: "nomic-embed-text:latest"},
+				{Name: "qwen3-embedding:8b"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	mgr := NewManager(srv.URL)
+	ctx := context.Background()
+
+	tests := []struct {
+		model string
+		found bool
+	}{
+		{"qwen3-embedding:8b", true},
+		{"nomic-embed-text", true},  // matches nomic-embed-text:latest
+		{"nomic-embed-text:latest", true},
+		{"nonexistent-model", false},
+	}
+
+	for _, tt := range tests {
+		has, err := mgr.HasModel(ctx, tt.model)
+		if err != nil {
+			t.Fatalf("HasModel(%q) error: %v", tt.model, err)
+		}
+		if has != tt.found {
+			t.Errorf("HasModel(%q) = %v, want %v", tt.model, has, tt.found)
+		}
+	}
+}
+
+func TestHasModel_OllamaDown(t *testing.T) {
+	mgr := NewManager("http://localhost:19999")
+	ctx := context.Background()
+
+	_, err := mgr.HasModel(ctx, "test-model")
+	if err == nil {
+		t.Fatal("expected error when Ollama is not reachable")
+	}
+}
+
+func TestWaitReady_AlreadyRunning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tagsResponse{})
+	}))
+	defer srv.Close()
+
+	mgr := NewManager(srv.URL)
+	ctx := context.Background()
+
+	err := mgr.WaitReady(ctx, 2*time.Second)
+	if err != nil {
+		t.Fatalf("WaitReady should succeed immediately: %v", err)
+	}
+}
+
+func TestWaitReady_Timeout(t *testing.T) {
+	mgr := NewManager("http://localhost:19999")
+	ctx := context.Background()
+
+	err := mgr.WaitReady(ctx, 1*time.Second)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestNewManager_DefaultURL(t *testing.T) {
+	mgr := NewManager("")
+	if mgr.BaseURL() != "http://localhost:11434" {
+		t.Errorf("expected default URL, got %s", mgr.BaseURL())
+	}
+}
+
+func TestNewManager_CustomURL(t *testing.T) {
+	mgr := NewManager("http://gpu-server:11434")
+	if mgr.BaseURL() != "http://gpu-server:11434" {
+		t.Errorf("expected custom URL, got %s", mgr.BaseURL())
+	}
+}
+
+func TestStartedByUs_DefaultFalse(t *testing.T) {
+	mgr := NewManager("")
+	if mgr.StartedByUs() {
+		t.Error("expected StartedByUs to be false by default")
+	}
+}

--- a/internal/ollama/process_unix.go
+++ b/internal/ollama/process_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package ollama
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess configures the command to run in its own process group on Unix.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/ollama/process_windows.go
+++ b/internal/ollama/process_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package ollama
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess configures the command to run as a detached process on Windows.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"github.com/lleontor705/cortex/internal/config"
 	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/lleontor705/cortex/internal/setup"
 	"github.com/lleontor705/cortex/internal/store/session"
@@ -30,6 +31,7 @@ const (
 	ScreenGraph
 	ScreenArchive
 	ScreenHealth
+	ScreenEmbeddingConfig
 )
 
 // ─── Aggregate types ────────────────────────────────────────────────────────
@@ -119,6 +121,31 @@ type setupInstallMsg struct {
 	err    error
 }
 
+// Embedding config messages
+type ollamaStatusMsg struct {
+	running  bool
+	hasModel bool
+	err      error
+}
+
+type ollamaStartMsg struct {
+	err error
+}
+
+type ollamaPullMsg struct {
+	done bool
+	err  error
+}
+
+type configSavedMsg struct {
+	err error
+}
+
+type configReloadedMsg struct {
+	cfg *config.Config
+	err error
+}
+
 // ─── Model ──────────────────────────────────────────────────────────────────
 
 // Model holds the TUI state.
@@ -194,6 +221,22 @@ type Model struct {
 	SetupAllowlistApplied bool
 	SetupAllowlistError   string
 	SetupSpinner          spinner.Model
+
+	// Embedding config
+	EmbCfgProvider       int             // 0=none, 1=ollama, 2=openai
+	EmbCfgModel          textinput.Model // model name input
+	EmbCfgVector         bool            // vector search toggle
+	EmbCfgAutoStart      bool            // auto-start Ollama toggle
+	EmbCfgFocusField     int             // focused field (0=provider, 1=model, 2=vector, 3=autostart, 4=save)
+	EmbCfgSaving         bool
+	EmbCfgSaved          bool
+	EmbCfgError          string
+	EmbCfgOllamaRunning  bool
+	EmbCfgOllamaHasModel bool
+	EmbCfgOllamaChecked  bool // true after status check completes
+	EmbCfgPulling        bool
+	EmbCfgStarting       bool
+	EmbCfgSpinner        spinner.Model
 }
 
 // New creates a new TUI model connected to the given stores.
@@ -207,12 +250,42 @@ func New(deps *Deps) Model {
 	sp.Spinner = spinner.Dot
 	sp.Style = lipgloss.NewStyle().Foreground(colorCyan)
 
+	embSp := spinner.New()
+	embSp.Spinner = spinner.Dot
+	embSp.Style = lipgloss.NewStyle().Foreground(colorCyan)
+
+	embModel := textinput.New()
+	embModel.Placeholder = "e.g. qwen3-embedding:8b"
+	embModel.CharLimit = 128
+	embModel.Width = 40
+
+	// Initialize embedding config from current config if available
+	embProvider := 0
+	embVector := false
+	embAutoStart := false
+	if deps.Config != nil {
+		switch deps.Config.Search.EmbeddingProvider {
+		case "ollama":
+			embProvider = 1
+		case "openai":
+			embProvider = 2
+		}
+		embModel.SetValue(deps.Config.Search.EmbeddingModel)
+		embVector = deps.Config.Search.Vector
+		embAutoStart = deps.Config.Search.OllamaAutoStart
+	}
+
 	return Model{
-		deps:         deps,
-		Version:      deps.Version,
-		Screen:       ScreenDashboard,
-		SearchInput:  ti,
-		SetupSpinner: sp,
+		deps:            deps,
+		Version:         deps.Version,
+		Screen:          ScreenDashboard,
+		SearchInput:     ti,
+		SetupSpinner:    sp,
+		EmbCfgSpinner:   embSp,
+		EmbCfgModel:     embModel,
+		EmbCfgProvider:   embProvider,
+		EmbCfgVector:     embVector,
+		EmbCfgAutoStart:  embAutoStart,
 	}
 }
 

--- a/internal/tui/store.go
+++ b/internal/tui/store.go
@@ -14,7 +14,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/lleontor705/cortex/internal/app"
+	"github.com/lleontor705/cortex/internal/config"
 	"github.com/lleontor705/cortex/internal/domain"
+	"github.com/lleontor705/cortex/internal/ollama"
 	entitystore "github.com/lleontor705/cortex/internal/store/entity"
 	graphstore "github.com/lleontor705/cortex/internal/store/graph"
 	scoringstore "github.com/lleontor705/cortex/internal/store/scoring"
@@ -34,6 +37,8 @@ type Deps struct {
 	Graph        *graphstore.Store
 	Scoring      *scoringstore.Store
 	Entities     *entitystore.Store
+	App          *app.App
+	Config       *config.Config
 	Version      string
 }
 
@@ -319,5 +324,74 @@ func loadHealthData(d *Deps, project string) tea.Cmd {
 			obsCount:   obsCount,
 			candidates: candidates,
 		}
+	}
+}
+
+// ─── Embedding Config Commands ─────────────────────────────────────────────
+
+var embeddingProviders = []string{"none", "ollama", "openai"}
+
+func saveEmbeddingConfig(d *Deps, provider int, model string, vector, autoStart bool) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Config == nil {
+			return configSavedMsg{err: fmt.Errorf("config not available")}
+		}
+		d.Config.Search.EmbeddingProvider = embeddingProviders[provider]
+		d.Config.Search.EmbeddingModel = model
+		d.Config.Search.Vector = vector
+		d.Config.Search.OllamaAutoStart = autoStart
+		err := config.Save(d.Config, "")
+		return configSavedMsg{err: err}
+	}
+}
+
+func checkOllamaStatus(d *Deps) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		baseURL := ""
+		model := ""
+		if d != nil && d.Config != nil {
+			baseURL = d.Config.Search.EmbeddingBaseURL
+			model = d.Config.Search.EmbeddingModel
+		}
+		mgr := ollama.NewManager(baseURL)
+		running := mgr.IsRunning(ctx)
+		hasModel := false
+		if running && model != "" {
+			hasModel, _ = mgr.HasModel(ctx, model)
+		}
+		return ollamaStatusMsg{running: running, hasModel: hasModel}
+	}
+}
+
+func startOllamaCmd(baseURL string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		mgr := ollama.NewManager(baseURL)
+		err := mgr.EnsureRunning(ctx)
+		return ollamaStartMsg{err: err}
+	}
+}
+
+func pullOllamaModelCmd(baseURL, model string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		mgr := ollama.NewManager(baseURL)
+		err := mgr.PullModel(ctx, model, nil)
+		return ollamaPullMsg{done: true, err: err}
+	}
+}
+
+func reloadConfigCmd(d *Deps) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.App == nil {
+			return configReloadedMsg{err: fmt.Errorf("app not available")}
+		}
+		if err := d.App.ReloadConfig(); err != nil {
+			return configReloadedMsg{err: err}
+		}
+		// Update the Deps config pointer to the reloaded config
+		d.Config = d.App.Config
+		return configReloadedMsg{cfg: d.App.Config}
 	}
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -30,6 +30,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenSearch && m.SearchInput.Focused() {
 			return m.handleSearchInputKeys(msg)
 		}
+		if m.Screen == ScreenEmbeddingConfig && m.EmbCfgModel.Focused() {
+			return m.handleEmbeddingModelInput(msg)
+		}
 		return m.handleKeyPress(msg.String())
 
 	// ─── Data loaded messages ────────────────────────────────────────
@@ -158,10 +161,88 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.SetupDone = true
 		return m, nil
 
+	case configSavedMsg:
+		m.EmbCfgSaving = false
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+			return m, nil
+		}
+		m.EmbCfgSaved = true
+		m.EmbCfgError = ""
+		// If ollama is configured, check its status
+		if m.EmbCfgProvider == 1 {
+			m.EmbCfgOllamaChecked = false
+			return m, checkOllamaStatus(m.deps)
+		}
+		return m, nil
+
+	case ollamaStatusMsg:
+		m.EmbCfgOllamaChecked = true
+		m.EmbCfgOllamaRunning = msg.running
+		m.EmbCfgOllamaHasModel = msg.hasModel
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+		}
+		return m, nil
+
+	case ollamaStartMsg:
+		m.EmbCfgStarting = false
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+			return m, nil
+		}
+		m.EmbCfgOllamaRunning = true
+		// After starting, check if model exists
+		return m, checkOllamaStatus(m.deps)
+
+	case ollamaPullMsg:
+		m.EmbCfgPulling = false
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+			return m, nil
+		}
+		m.EmbCfgOllamaHasModel = true
+		return m, nil
+
+	case configReloadedMsg:
+		m.EmbCfgSaving = false
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+			return m, nil
+		}
+		// Sync TUI state with reloaded config
+		if msg.cfg != nil {
+			switch msg.cfg.Search.EmbeddingProvider {
+			case "ollama":
+				m.EmbCfgProvider = 1
+			case "openai":
+				m.EmbCfgProvider = 2
+			default:
+				m.EmbCfgProvider = 0
+			}
+			m.EmbCfgModel.SetValue(msg.cfg.Search.EmbeddingModel)
+			m.EmbCfgVector = msg.cfg.Search.Vector
+			m.EmbCfgAutoStart = msg.cfg.Search.OllamaAutoStart
+		}
+		m.EmbCfgSaved = false
+		m.EmbCfgError = ""
+		m.EmbCfgOllamaChecked = false
+		m.ErrorMsg = ""
+		// Check Ollama status if ollama is configured
+		if m.EmbCfgProvider == 1 {
+			return m, checkOllamaStatus(m.deps)
+		}
+		return m, nil
+
 	case spinner.TickMsg:
 		if m.SetupInstalling {
 			var cmd tea.Cmd
 			m.SetupSpinner, cmd = m.SetupSpinner.Update(msg)
+			return m, cmd
+		}
+		if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving {
+			var cmd tea.Cmd
+			m.EmbCfgSpinner, cmd = m.EmbCfgSpinner.Update(msg)
 			return m, cmd
 		}
 		return m, nil
@@ -200,6 +281,8 @@ func (m Model) handleKeyPress(key string) (tea.Model, tea.Cmd) {
 		return m.handleArchiveKeys(key)
 	case ScreenHealth:
 		return m.handleHealthKeys(key)
+	case ScreenEmbeddingConfig:
+		return m.handleEmbeddingConfigKeys(key)
 	}
 	return m, nil
 }
@@ -213,6 +296,7 @@ var dashboardMenuItems = []string{
 	"Knowledge graph",
 	"Memory health",
 	"Archived observations",
+	"Embedding settings",
 	"Setup agent plugin",
 	"Quit",
 }
@@ -290,7 +374,33 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.Cursor = 0
 		m.Scroll = 0
 		return m, loadArchivedObservations(m.deps)
-	case 6: // Setup
+	case 6: // Embedding settings
+		m.PrevScreen = ScreenDashboard
+		m.Screen = ScreenEmbeddingConfig
+		m.Cursor = 0
+		m.EmbCfgFocusField = 0
+		m.EmbCfgSaved = false
+		m.EmbCfgSaving = false
+		m.EmbCfgError = ""
+		m.EmbCfgOllamaChecked = false
+		m.EmbCfgPulling = false
+		m.EmbCfgStarting = false
+		// Reload current config values
+		if m.deps.Config != nil {
+			switch m.deps.Config.Search.EmbeddingProvider {
+			case "ollama":
+				m.EmbCfgProvider = 1
+			case "openai":
+				m.EmbCfgProvider = 2
+			default:
+				m.EmbCfgProvider = 0
+			}
+			m.EmbCfgModel.SetValue(m.deps.Config.Search.EmbeddingModel)
+			m.EmbCfgVector = m.deps.Config.Search.Vector
+			m.EmbCfgAutoStart = m.deps.Config.Search.OllamaAutoStart
+		}
+		return m, nil
+	case 7: // Setup
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSetup
 		m.Cursor = 0
@@ -304,7 +414,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.SetupAllowlistApplied = false
 		m.SetupAllowlistError = ""
 		return m, nil
-	case 7: // Quit
+	case 8: // Quit
 		return m, tea.Quit
 	}
 	return m, nil
@@ -760,6 +870,123 @@ func (m Model) handleSetupKeys(key string) (tea.Model, tea.Cmd) {
 			m.SetupInstalling = true
 			m.SetupInstallingName = agent.Name
 			return m, tea.Batch(m.SetupSpinner.Tick, installAgent(agent.Name))
+		}
+	case "esc", "q":
+		m.Screen = ScreenDashboard
+		m.Cursor = 0
+		return m, loadStats(m.deps)
+	}
+	return m, nil
+}
+
+// ──�� Embedding Config ───────────────────────────────────────────────────────
+
+func (m Model) handleEmbeddingModelInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter", "esc":
+		m.EmbCfgModel.Blur()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.EmbCfgModel, cmd = m.EmbCfgModel.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handleEmbeddingConfigKeys(key string) (tea.Model, tea.Cmd) {
+	// If async operation running, only allow esc
+	if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving {
+		return m, nil
+	}
+
+	// Post-save Ollama actions
+	if m.EmbCfgSaved && m.EmbCfgProvider == 1 && m.EmbCfgOllamaChecked {
+		switch key {
+		case "s", "S":
+			if !m.EmbCfgOllamaRunning {
+				m.EmbCfgStarting = true
+				m.EmbCfgError = ""
+				baseURL := ""
+				if m.deps.Config != nil {
+					baseURL = m.deps.Config.Search.EmbeddingBaseURL
+				}
+				return m, tea.Batch(m.EmbCfgSpinner.Tick, startOllamaCmd(baseURL))
+			}
+		case "p", "P":
+			if m.EmbCfgOllamaRunning && !m.EmbCfgOllamaHasModel {
+				m.EmbCfgPulling = true
+				m.EmbCfgError = ""
+				baseURL := ""
+				model := m.EmbCfgModel.Value()
+				if m.deps.Config != nil {
+					baseURL = m.deps.Config.Search.EmbeddingBaseURL
+				}
+				return m, tea.Batch(m.EmbCfgSpinner.Tick, pullOllamaModelCmd(baseURL, model))
+			}
+		case "esc", "q", "enter":
+			m.Screen = ScreenDashboard
+			m.Cursor = 0
+			return m, loadStats(m.deps)
+		}
+		return m, nil
+	}
+
+	// Post-save (non-ollama or not yet checked)
+	if m.EmbCfgSaved {
+		switch key {
+		case "esc", "q", "enter":
+			m.Screen = ScreenDashboard
+			m.Cursor = 0
+			return m, loadStats(m.deps)
+		}
+		return m, nil
+	}
+
+	// Reload config from disk (r key works in any non-editing state)
+	if key == "r" || key == "R" {
+		m.EmbCfgSaving = true
+		m.EmbCfgError = ""
+		return m, tea.Batch(m.EmbCfgSpinner.Tick, reloadConfigCmd(m.deps))
+	}
+
+	maxField := 4 // provider(0), model(1), vector(2), autostart(3), save(4)
+
+	switch key {
+	case "up", "k":
+		if m.EmbCfgFocusField > 0 {
+			m.EmbCfgFocusField--
+		}
+	case "down", "j":
+		if m.EmbCfgFocusField < maxField {
+			m.EmbCfgFocusField++
+		}
+	case "left", "h":
+		if m.EmbCfgFocusField == 0 {
+			m.EmbCfgProvider = (m.EmbCfgProvider + 2) % 3 // cycle left
+		}
+	case "right", "l":
+		if m.EmbCfgFocusField == 0 {
+			m.EmbCfgProvider = (m.EmbCfgProvider + 1) % 3 // cycle right
+		}
+	case " ":
+		switch m.EmbCfgFocusField {
+		case 2:
+			m.EmbCfgVector = !m.EmbCfgVector
+		case 3:
+			m.EmbCfgAutoStart = !m.EmbCfgAutoStart
+		}
+	case "enter":
+		switch m.EmbCfgFocusField {
+		case 1: // Focus model text input
+			m.EmbCfgModel.Focus()
+			return m, nil
+		case 4: // Save
+			m.EmbCfgSaving = true
+			m.EmbCfgSaved = false
+			m.EmbCfgError = ""
+			return m, tea.Batch(
+				m.EmbCfgSpinner.Tick,
+				saveEmbeddingConfig(m.deps, m.EmbCfgProvider, m.EmbCfgModel.Value(), m.EmbCfgVector, m.EmbCfgAutoStart),
+			)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -80,6 +80,8 @@ func (m Model) View() string {
 		content = m.viewArchive()
 	case ScreenHealth:
 		content = m.viewHealth()
+	case ScreenEmbeddingConfig:
+		content = m.viewEmbeddingConfig()
 	default:
 		content = "Unknown screen"
 	}
@@ -987,4 +989,132 @@ func entityIcon(entityType string) string {
 	default:
 		return "*"
 	}
+}
+
+// ─── Embedding Config ──────────────────────────────────────────────────────
+
+func (m Model) viewEmbeddingConfig() string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("  Embedding Settings"))
+	b.WriteString("\n\n")
+
+	providers := []string{"none", "ollama", "openai"}
+	focusMarker := func(field int) string {
+		if m.EmbCfgFocusField == field {
+			return listSelectedStyle.Render("▸ ")
+		}
+		return "  "
+	}
+
+	labelStyle := lipgloss.NewStyle().Width(14).Foreground(colorText)
+	valueStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(colorSubtext)
+
+	// Provider selector (field 0)
+	providerDisplay := fmt.Sprintf("◂ %s ▸", providers[m.EmbCfgProvider])
+	b.WriteString(focusMarker(0) + labelStyle.Render("Provider:") + " " + valueStyle.Render(providerDisplay))
+	b.WriteString("\n")
+
+	// Model input (field 1)
+	if m.EmbCfgModel.Focused() {
+		b.WriteString(focusMarker(1) + labelStyle.Render("Model:") + " " + m.EmbCfgModel.View())
+	} else {
+		modelVal := m.EmbCfgModel.Value()
+		if modelVal == "" {
+			modelVal = dimStyle.Render("(default)")
+		} else {
+			modelVal = valueStyle.Render(modelVal)
+		}
+		b.WriteString(focusMarker(1) + labelStyle.Render("Model:") + " " + modelVal)
+	}
+	b.WriteString("\n")
+
+	// Vector toggle (field 2)
+	vectorCheck := dimStyle.Render("[ ] Disabled")
+	if m.EmbCfgVector {
+		vectorCheck = lipgloss.NewStyle().Foreground(colorGreen).Render("[x] Enabled")
+	}
+	b.WriteString(focusMarker(2) + labelStyle.Render("Vector:") + " " + vectorCheck)
+	b.WriteString("\n")
+
+	// Auto-start toggle (field 3)
+	autoCheck := dimStyle.Render("[ ] Disabled")
+	if m.EmbCfgAutoStart {
+		autoCheck = lipgloss.NewStyle().Foreground(colorGreen).Render("[x] Enabled")
+	}
+	b.WriteString(focusMarker(3) + labelStyle.Render("Auto-start:") + " " + autoCheck)
+	b.WriteString("\n\n")
+
+	// Save button (field 4)
+	if m.EmbCfgFocusField == 4 {
+		b.WriteString("  " + lipgloss.NewStyle().Background(colorCyan).Foreground(lipgloss.Color("#16161e")).Bold(true).Padding(0, 2).Render("Save"))
+	} else {
+		b.WriteString("  " + lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorOverlay).Padding(0, 2).Render("Save"))
+	}
+	b.WriteString("\n")
+
+	// Status messages
+	if m.EmbCfgSaving {
+		b.WriteString("\n  " + m.EmbCfgSpinner.View() + " Saving configuration...")
+	}
+
+	if m.EmbCfgError != "" {
+		b.WriteString("\n  " + errorStyle.Render("Error: "+m.EmbCfgError))
+	}
+
+	if m.EmbCfgSaved {
+		b.WriteString("\n  " + lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render("Configuration saved."))
+
+		// Ollama status section
+		if m.EmbCfgProvider == 1 {
+			b.WriteString("\n")
+			b.WriteString("\n  " + lipgloss.NewStyle().Foreground(colorPurple).Bold(true).Render("── Ollama Status ──"))
+			b.WriteString("\n")
+
+			if !m.EmbCfgOllamaChecked {
+				b.WriteString("  " + m.EmbCfgSpinner.View() + " Checking Ollama status...")
+			} else {
+				// Running status
+				if m.EmbCfgOllamaRunning {
+					b.WriteString("  " + lipgloss.NewStyle().Foreground(colorGreen).Render("● Running"))
+				} else {
+					b.WriteString("  " + lipgloss.NewStyle().Foreground(colorRed).Render("● Stopped"))
+					b.WriteString("  " + dimStyle.Render("Press [s] to start Ollama"))
+				}
+
+				// Model status
+				if m.EmbCfgOllamaRunning {
+					if m.EmbCfgOllamaHasModel {
+						b.WriteString("    " + lipgloss.NewStyle().Foreground(colorGreen).Render("Model: found"))
+					} else {
+						modelName := m.EmbCfgModel.Value()
+						if modelName == "" {
+							modelName = "default model"
+						}
+						b.WriteString("    " + lipgloss.NewStyle().Foreground(colorAmber).Render("Model: not found"))
+						b.WriteString("\n  " + dimStyle.Render(fmt.Sprintf("Press [p] to pull %s", modelName)))
+					}
+				}
+			}
+
+			if m.EmbCfgStarting {
+				b.WriteString("\n  " + m.EmbCfgSpinner.View() + " Starting Ollama...")
+			}
+			if m.EmbCfgPulling {
+				b.WriteString("\n  " + m.EmbCfgSpinner.View() + " Pulling model...")
+			}
+		}
+	}
+
+	// Help
+	if m.EmbCfgSaved {
+		b.WriteString(helpStyle.Render("\n\n  esc back to dashboard"))
+	} else if m.EmbCfgModel.Focused() {
+		b.WriteString(helpStyle.Render("\n\n  Type model name • enter confirm • esc cancel"))
+	} else {
+		b.WriteString(helpStyle.Render("\n\n  j/k navigate • h/l cycle provider • space toggle • enter edit/save • r reload config • esc back"))
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
## Summary
- Add interactive TUI screen (13th) for configuring embedding settings: provider (none/ollama/openai), model name, vector search toggle, and Ollama auto-start
- New `internal/ollama/` package for Ollama lifecycle management: health checks, background process launch, readiness polling, model detection and pulling
- Config persistence via `Save()` function — TUI writes changes to `~/.cortex/cortex.yaml`; default config auto-created on first run
- CLI `reindex` command auto-starts Ollama and pulls missing models before indexing
- Hot reload (`r` key) re-reads config from disk and reinitializes embedding service without restart

## New files
- `internal/ollama/ollama.go` — Ollama process manager (IsRunning, Start, WaitReady, HasModel, PullModel, EnsureRunning)
- `internal/ollama/process_windows.go` / `process_unix.go` — Platform-specific process detachment
- `internal/ollama/ollama_test.go` — 9 unit tests with httptest mocks

## Modified files
- `internal/config/config.go` — `Save()`, `ensureDefaultConfig()`, new fields: `embedding_model`, `embedding_base_url`, `ollama_auto_start`
- `internal/app/app.go` — `ReloadConfig()`, BaseURL pass to embedding service, optional Ollama auto-start
- `internal/cli/cli.go` — Config + App in TUI deps, Ollama auto-start in reindex
- `internal/tui/model.go` — `ScreenEmbeddingConfig`, message types, model fields
- `internal/tui/store.go` — `App` + `Config` in Deps, async commands (save, check, start, pull, reload)
- `internal/tui/update.go` — Dashboard menu item, key handlers, message handlers
- `internal/tui/view.go` — `viewEmbeddingConfig()` with provider selector, model input, toggles, Ollama status

## Test plan
- [x] `go build -tags cortex_vectors ./cmd/cortex` compiles
- [x] `go test ./internal/ollama/...` — 9/9 pass
- [x] `go test ./internal/config/...` — all pass
- [x] `go test ./...` — all existing tests pass (pre-existing sqlite test issue unrelated)
- [ ] Manual: `cortex tui` → Dashboard → "Embedding settings" → configure ollama + model → save → start → pull
- [ ] Manual: `cortex reindex --project test` with ollama configured → auto-starts and pulls
- [ ] Manual: edit `~/.cortex/cortex.yaml` by hand → press `r` in TUI → values refresh