### PR TITLE
fix: enable cortex_vectors build tag in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    tags:
+      - cortex_vectors
     ldflags:
       - -s -w -X main.version={{.Version}}
 


### PR DESCRIPTION
## Summary
- Release binaries (v1.1.0 and prior) were compiled without the `cortex_vectors` build tag
- This caused `cortex reindex` to fail with "vector store not available" and disabled all vector search functionality in distributed binaries
- Adds `tags: [cortex_vectors]` to `.goreleaser.yaml` so all future releases include vector search support out of the box

## Test plan
- [x] All existing tests pass
- [ ] Next release build includes vector store enabled (`cortex doctor` shows `[OK] Vector store: enabled`)