### PR TITLE
fix: enable cortex_vectors build tag in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    tags:
+      - cortex_vectors
     ldflags:
       - -s -w -X main.version={{.Version}}
 


### PR DESCRIPTION
Release binaries were compiled without vector search support. Adding the cortex_vectors tag ensures all releases include Ollama/OpenAI embedding and vector search capabilities.