### PR TITLE
feat: fix hybrid search bugs + comprehensive TUI improvements

### DIFF
--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -137,7 +137,7 @@ type ScoringRepository interface {
 
 // VectorSearchOptions provides options for vector similarity search.
 type VectorSearchOptions struct {
-	// Embedding is the query embedding vector (384 dimensions).
+	// Embedding is the query embedding vector (64-4096 dimensions depending on model).
 	Embedding []float32
 	// Limit is the maximum number of results to return.
 	Limit int
@@ -163,7 +163,7 @@ type VectorSearchResult struct {
 // When not enabled, all methods return ErrVectorSearchDisabled.
 type VectorRepository interface {
 	// StoreEmbedding stores an embedding vector for an observation.
-	// The embedding must have exactly 384 dimensions.
+	// The embedding dimensions must be between 64 and 4096.
 	// Returns an error if the observation doesn't exist or embedding dimension is wrong.
 	StoreEmbedding(ctx context.Context, observationID int64, embedding []float32, model string) error
 

--- a/internal/embedding/service.go
+++ b/internal/embedding/service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -77,6 +78,7 @@ type ollamaService struct {
 	baseURL string
 	model   string
 	dims    int // cached after first call
+	mu      sync.Mutex
 }
 
 func (s *ollamaService) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -122,14 +124,18 @@ func (s *ollamaService) Embed(ctx context.Context, text string) ([]float32, erro
 	}
 
 	// Cache dimensions from first result
+	s.mu.Lock()
 	if s.dims == 0 {
 		s.dims = len(vec)
 	}
+	s.mu.Unlock()
 
 	return vec, nil
 }
 
 func (s *ollamaService) Dimensions() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.dims > 0 {
 		return s.dims
 	}
@@ -144,6 +150,8 @@ func (s *ollamaService) Model() string { return s.model }
 type openAIService struct {
 	apiKey string
 	model  string
+	dims   int
+	mu     sync.Mutex
 }
 
 func (s *openAIService) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -183,8 +191,25 @@ func (s *openAIService) Embed(ctx context.Context, text string) ([]float32, erro
 		return nil, fmt.Errorf("openai: no data returned")
 	}
 
-	return result.Data[0].Embedding, nil
+	vec := result.Data[0].Embedding
+
+	// Cache dimensions from first result
+	s.mu.Lock()
+	if s.dims == 0 {
+		s.dims = len(vec)
+	}
+	s.mu.Unlock()
+
+	return vec, nil
 }
 
-func (s *openAIService) Dimensions() int { return 1536 }
+func (s *openAIService) Dimensions() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.dims > 0 {
+		return s.dims
+	}
+	// Default for text-embedding-3-small
+	return 1536
+}
 func (s *openAIService) Model() string   { return s.model }

--- a/internal/mcp/tools_cortex.go
+++ b/internal/mcp/tools_cortex.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"time"
@@ -385,12 +386,11 @@ func handleSearchHybrid(stores *Stores) server.ToolHandlerFunc {
 
 			// Prefer generating a real query embedding via the embedding service
 			if stores.Embeddings != nil {
-				queryVec, _ = stores.Embeddings.Embed(ctx, query)
-			}
-
-			// Fallback: use first FTS5 result's stored embedding as proxy
-			if len(queryVec) == 0 && len(ftsResults) > 0 {
-				queryVec, _, _ = stores.Vectors.GetEmbedding(ctx, ftsResults[0].ID)
+				var embedErr error
+				queryVec, embedErr = stores.Embeddings.Embed(ctx, query)
+				if embedErr != nil {
+					log.Printf("warning: hybrid search embed failed, falling back to FTS5: %v", embedErr)
+				}
 			}
 
 			if len(queryVec) > 0 {

--- a/internal/mcp/tools_memory.go
+++ b/internal/mcp/tools_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -550,11 +551,18 @@ func handleSave(stores *Stores) server.ToolHandlerFunc {
 		// Auto-embed for vector search (best-effort, non-blocking)
 		if stores.Embeddings != nil && stores.Vectors != nil && stores.Vectors.IsAvailable() {
 			go func() {
-				bgCtx := context.Background()
+				bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
 				text := obs.Title + "\n" + obs.Content
 				vec, err := stores.Embeddings.Embed(bgCtx, text)
-				if err == nil && len(vec) > 0 {
-					_ = stores.Vectors.StoreEmbedding(bgCtx, obs.ID, vec, stores.Embeddings.Model())
+				if err != nil {
+					log.Printf("warning: auto-embed failed for obs %d: %v", obs.ID, err)
+					return
+				}
+				if len(vec) > 0 {
+					if storeErr := stores.Vectors.StoreEmbedding(bgCtx, obs.ID, vec, stores.Embeddings.Model()); storeErr != nil {
+						log.Printf("warning: store embedding failed for obs %d: %v", obs.ID, storeErr)
+					}
 				}
 			}()
 		}

--- a/internal/store/sqlite/memory_store.go
+++ b/internal/store/sqlite/memory_store.go
@@ -338,6 +338,30 @@ func (s *Store) HardDelete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// Restore un-archives a soft-deleted observation by clearing its deleted_at timestamp.
+// Returns ErrNotFound if the observation doesn't exist or is not archived.
+func (s *Store) Restore(ctx context.Context, id int64) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE observations
+		SET deleted_at = NULL, updated_at = datetime('now')
+		WHERE id = ? AND deleted_at IS NOT NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("memory store: restore observation: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("memory store: get rows affected: %w", err)
+	}
+
+	if affected == 0 {
+		return &domain.NotFoundError{Type: "observation", ID: id}
+	}
+
+	return nil
+}
+
 // ListArchivable retrieves observations older than cutoff with score below minScore.
 // Uses a JOIN with importance_scores to avoid N+1 queries during archival.
 func (s *Store) ListArchivable(ctx context.Context, cutoff time.Time, minScore float64, limit int) ([]*domain.Observation, error) {

--- a/internal/store/sqlite/vector_store_enabled.go
+++ b/internal/store/sqlite/vector_store_enabled.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"time"
@@ -43,7 +44,7 @@ func NewVectorStore(db *sql.DB) *VectorStore {
 }
 
 // StoreEmbedding stores an embedding vector for an observation.
-// The embedding must have exactly EmbeddingDimension (384) dimensions.
+// The embedding must have between MinEmbeddingDimension and MaxEmbeddingDimension dimensions.
 // The model parameter identifies the embedding model used (e.g., "all-MiniLM-L6-v2").
 func (s *VectorStore) StoreEmbedding(ctx context.Context, observationID int64, embedding []float32, model string) error {
 	// Validate embedding dimension (flexible — accept any reasonable size)
@@ -283,6 +284,7 @@ func normalizeVector(v []float32) []float64 {
 // Both vectors should be pre-normalized for efficiency.
 func cosineSimilarity(a []float64, b []float32) float64 {
 	if len(a) != len(b) {
+		log.Printf("warning: cosine similarity dimension mismatch: query=%d stored=%d", len(a), len(b))
 		return 0
 	}
 
@@ -314,6 +316,7 @@ func computeCosineSimilarity(queryNorm []float64, embedding []float32) float64 {
 
 	// Dot product of normalized vectors
 	if len(queryNorm) != len(embF64) {
+		log.Printf("warning: cosine similarity dimension mismatch: query=%d stored=%d", len(queryNorm), len(embF64))
 		return 0
 	}
 	var dot float64

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -146,6 +146,16 @@ type configReloadedMsg struct {
 	err error
 }
 
+type deleteObservationMsg struct {
+	id  int64
+	err error
+}
+
+type unarchiveObservationMsg struct {
+	id  int64
+	err error
+}
+
 // ─── Model ──────────────────────────────────────────────────────────────────
 
 // Model holds the TUI state.
@@ -170,9 +180,11 @@ type Model struct {
 	Stats *combinedStats
 
 	// Search
-	SearchInput   textinput.Model
-	SearchQuery   string
-	SearchResults []*domain.SearchResult
+	SearchInput      textinput.Model
+	SearchQuery      string
+	SearchResults    []*domain.SearchResult
+	SearchHistory    []string
+	SearchHistoryIdx int
 
 	// Recent observations
 	RecentObservations []*domain.Observation
@@ -183,6 +195,7 @@ type Model struct {
 	DetailEntities      []*domain.EntityLink
 	DetailEdges         []*domain.Edge
 	DetailScroll        int
+	DetailLoading       bool
 
 	// Timeline
 	TimelineFocus  *domain.Observation
@@ -200,8 +213,20 @@ type Model struct {
 	GraphEdges        []*domain.Edge
 	GraphRootID       int64
 
+	// List filtering
+	FilterProject string // active project filter ("" = all)
+	FilterActive  bool   // whether filter is shown
+
+	// Vim multi-key sequences
+	PendingKey string // for multi-key sequences like "gg"
+
 	// Archive (Cortex-exclusive)
 	ArchivedObservations []*domain.Observation
+
+	// Delete confirmation
+	ConfirmDelete      bool
+	DeleteTargetID     int64
+	DeleteTargetTitle  string
 
 	// Health (Cortex-exclusive)
 	HealthStale      []*domain.Observation
@@ -209,6 +234,8 @@ type Model struct {
 	HealthEdgeCount  int
 	HealthObsCount   int
 	HealthCandidates []healthCandidate
+	HealthSection    int  // 0=stale, 1=orphans, 2=candidates
+	HealthExpanded   bool
 
 	// Setup
 	SetupAgents           []setup.Agent
@@ -223,6 +250,7 @@ type Model struct {
 	SetupSpinner          spinner.Model
 
 	// Embedding config
+	EmbCfgDirty          bool
 	EmbCfgProvider       int             // 0=none, 1=ollama, 2=openai
 	EmbCfgModel          textinput.Model // model name input
 	EmbCfgVector         bool            // vector search toggle

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -356,7 +356,7 @@ func TestLoadStatsWithNilObservations(t *testing.T) {
 }
 
 func TestLoadSearchWithNilDeps(t *testing.T) {
-	cmd := searchMemories(nil, "test")
+	cmd := searchMemories(nil, "test", "")
 	msg := cmd()
 	loaded, ok := msg.(searchResultsMsg)
 	if !ok {

--- a/internal/tui/store.go
+++ b/internal/tui/store.go
@@ -94,24 +94,24 @@ func loadStats(d *Deps) tea.Cmd {
 	}
 }
 
-func searchMemories(d *Deps, query string) tea.Cmd {
+func searchMemories(d *Deps, query string, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Search == nil {
 			return searchResultsMsg{err: fmt.Errorf("search store not available")}
 		}
 		ctx := context.Background()
-		results, err := d.Search.Search(ctx, query, domain.SearchOptions{Limit: 50})
+		results, err := d.Search.Search(ctx, query, domain.SearchOptions{Limit: 50, Project: project})
 		return searchResultsMsg{results: results, query: query, err: err}
 	}
 }
 
-func loadRecentObservations(d *Deps) tea.Cmd {
+func loadRecentObservations(d *Deps, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Observations == nil {
 			return recentObservationsMsg{err: fmt.Errorf("observations store not available")}
 		}
 		ctx := context.Background()
-		obs, err := d.Observations.List(ctx, domain.ObservationFilter{Limit: 50})
+		obs, err := d.Observations.List(ctx, domain.ObservationFilter{Limit: 50, Project: project})
 		return recentObservationsMsg{observations: obs, err: err}
 	}
 }
@@ -249,7 +249,7 @@ func loadGraphRelated(d *Deps, obsID int64) tea.Cmd {
 	}
 }
 
-func loadArchivedObservations(d *Deps) tea.Cmd {
+func loadArchivedObservations(d *Deps, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Observations == nil {
 			return archiveLoadedMsg{err: fmt.Errorf("observations store not available")}
@@ -258,6 +258,7 @@ func loadArchivedObservations(d *Deps) tea.Cmd {
 		obs, err := d.Observations.List(ctx, domain.ObservationFilter{
 			Limit:           50,
 			IncludeArchived: true,
+			Project:         project,
 		})
 		return archiveLoadedMsg{observations: obs, err: err}
 	}
@@ -324,6 +325,30 @@ func loadHealthData(d *Deps, project string) tea.Cmd {
 			obsCount:   obsCount,
 			candidates: candidates,
 		}
+	}
+}
+
+// ─── Delete / Unarchive Commands ──────────────────────────────────────────
+
+func deleteObservation(d *Deps, id int64) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Observations == nil {
+			return deleteObservationMsg{id: id, err: fmt.Errorf("observations store not available")}
+		}
+		ctx := context.Background()
+		err := d.Observations.Delete(ctx, id)
+		return deleteObservationMsg{id: id, err: err}
+	}
+}
+
+func unarchiveObservation(d *Deps, id int64) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Observations == nil {
+			return unarchiveObservationMsg{id: id, err: fmt.Errorf("observations store not available")}
+		}
+		ctx := context.Background()
+		err := d.Observations.Restore(ctx, id)
+		return unarchiveObservationMsg{id: id, err: err}
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -69,6 +69,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case observationDetailMsg:
+		m.DetailLoading = false
 		if msg.err != nil {
 			m.ErrorMsg = msg.err.Error()
 			return m, nil
@@ -169,6 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.EmbCfgSaved = true
 		m.EmbCfgError = ""
+		m.EmbCfgDirty = false
 		// If ollama is configured, check its status
 		if m.EmbCfgProvider == 1 {
 			m.EmbCfgOllamaChecked = false
@@ -206,6 +208,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case configReloadedMsg:
 		m.EmbCfgSaving = false
+		m.EmbCfgDirty = false
 		if msg.err != nil {
 			m.EmbCfgError = msg.err.Error()
 			return m, nil
@@ -234,7 +237,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case deleteObservationMsg:
+		m.ConfirmDelete = false
+		if msg.err != nil {
+			m.ErrorMsg = msg.err.Error()
+			return m, nil
+		}
+		return m, m.refreshScreen(m.Screen)
+
+	case unarchiveObservationMsg:
+		if msg.err != nil {
+			m.ErrorMsg = msg.err.Error()
+			return m, nil
+		}
+		return m, m.refreshScreen(m.Screen)
+
 	case spinner.TickMsg:
+		if m.DetailLoading {
+			var cmd tea.Cmd
+			m.SetupSpinner, cmd = m.SetupSpinner.Update(msg)
+			return m, cmd
+		}
 		if m.SetupInstalling {
 			var cmd tea.Cmd
 			m.SetupSpinner, cmd = m.SetupSpinner.Update(msg)
@@ -340,7 +363,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.Screen = ScreenRecent
 		m.Cursor = 0
 		m.Scroll = 0
-		return m, loadRecentObservations(m.deps)
+		return m, loadRecentObservations(m.deps, m.FilterProject)
 	case 2: // Sessions
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSessions
@@ -357,7 +380,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 			m.GraphRootID = m.RecentObservations[0].ID
 			return m, loadGraphRelated(m.deps, m.GraphRootID)
 		}
-		return m, loadRecentObservations(m.deps)
+		return m, loadRecentObservations(m.deps, m.FilterProject)
 	case 4: // Memory health
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenHealth
@@ -373,7 +396,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.Screen = ScreenArchive
 		m.Cursor = 0
 		m.Scroll = 0
-		return m, loadArchivedObservations(m.deps)
+		return m, loadArchivedObservations(m.deps, m.FilterProject)
 	case 6: // Embedding settings
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenEmbeddingConfig
@@ -382,6 +405,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.EmbCfgSaved = false
 		m.EmbCfgSaving = false
 		m.EmbCfgError = ""
+		m.EmbCfgDirty = false
 		m.EmbCfgOllamaChecked = false
 		m.EmbCfgPulling = false
 		m.EmbCfgStarting = false
@@ -427,10 +451,35 @@ func (m Model) handleSearchInputKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		query := m.SearchInput.Value()
 		if query != "" {
+			// Append to search history (max 20 entries)
+			m.SearchHistory = append(m.SearchHistory, query)
+			if len(m.SearchHistory) > 20 {
+				m.SearchHistory = m.SearchHistory[len(m.SearchHistory)-20:]
+			}
+			m.SearchHistoryIdx = len(m.SearchHistory)
 			m.SearchInput.Blur()
-			return m, searchMemories(m.deps, query)
+			return m, searchMemories(m.deps, query, m.FilterProject)
 		}
 		return m, nil
+	case "up":
+		if len(m.SearchHistory) > 0 {
+			if m.SearchHistoryIdx > 0 {
+				m.SearchHistoryIdx--
+			}
+			m.SearchInput.SetValue(m.SearchHistory[m.SearchHistoryIdx])
+			return m, nil
+		}
+	case "down":
+		if len(m.SearchHistory) > 0 {
+			if m.SearchHistoryIdx < len(m.SearchHistory)-1 {
+				m.SearchHistoryIdx++
+				m.SearchInput.SetValue(m.SearchHistory[m.SearchHistoryIdx])
+			} else {
+				m.SearchHistoryIdx = len(m.SearchHistory)
+				m.SearchInput.SetValue("")
+			}
+			return m, nil
+		}
 	case "esc":
 		m.SearchInput.Blur()
 		m.Screen = ScreenDashboard
@@ -464,7 +513,38 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservation(m.deps, m.DeleteTargetID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.SearchResults) > 0 {
+			m.Cursor = len(m.SearchResults) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -484,7 +564,8 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			obsID := m.SearchResults[m.Cursor].ID
 			m.PrevScreen = ScreenSearchResults
 			m.PrevCursor = m.Cursor
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
@@ -493,6 +574,27 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevCursor = m.Cursor
 			return m, loadTimeline(m.deps, obsID)
 		}
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, searchMemories(m.deps, m.SearchQuery, m.FilterProject)
+		}
+	case "d":
+		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
+			obs := m.SearchResults[m.Cursor]
+			m.ConfirmDelete = true
+			m.DeleteTargetID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
 	case "/", "s":
 		m.PrevScreen = ScreenSearchResults
 		m.Screen = ScreenSearch
@@ -517,7 +619,38 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservation(m.deps, m.DeleteTargetID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.RecentObservations) > 0 {
+			m.Cursor = len(m.RecentObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -537,7 +670,8 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			obsID := m.RecentObservations[m.Cursor].ID
 			m.PrevScreen = ScreenRecent
 			m.PrevCursor = m.Cursor
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
@@ -545,6 +679,27 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenRecent
 			m.PrevCursor = m.Cursor
 			return m, loadTimeline(m.deps, obsID)
+		}
+	case "d":
+		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
+			obs := m.RecentObservations[m.Cursor]
+			m.ConfirmDelete = true
+			m.DeleteTargetID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, loadRecentObservations(m.deps, m.FilterProject)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard
@@ -558,6 +713,17 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Observation Detail ─────────────────────────────────────────────────────
 
 func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservation(m.deps, m.DeleteTargetID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
 	case "up", "k":
 		if m.DetailScroll > 0 {
@@ -582,6 +748,21 @@ func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenObservationDetail
 			return m, loadGraphRelated(m.deps, m.SelectedObservation.ID)
 		}
+	case "s", "S":
+		if m.SelectedObservation != nil && m.SelectedObservation.SessionID != "" {
+			m.PrevScreen = ScreenObservationDetail
+			m.Screen = ScreenSessionDetail
+			m.Cursor = 0
+			m.SessionDetailScroll = 0
+			return m, loadSessionObservations(m.deps, m.SelectedObservation.SessionID)
+		}
+	case "d":
+		if m.SelectedObservation != nil {
+			m.ConfirmDelete = true
+			m.DeleteTargetID = m.SelectedObservation.ID
+			m.DeleteTargetTitle = m.SelectedObservation.Title
+		}
+		return m, nil
 	case "esc", "q":
 		m.Screen = m.PrevScreen
 		m.Cursor = m.PrevCursor
@@ -621,7 +802,27 @@ func (m Model) handleSessionsKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems + 2
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
 	switch key {
+	case "G":
+		if len(m.Sessions) > 0 {
+			m.Cursor = len(m.Sessions) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -679,7 +880,8 @@ func (m Model) handleSessionDetailKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {
 			obsID := m.SessionObservations[m.Cursor].ID
 			m.PrevScreen = ScreenSessionDetail
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {
@@ -704,7 +906,27 @@ func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
 	switch key {
+	case "G":
+		if len(m.GraphObservations) > 0 {
+			m.Cursor = len(m.GraphObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -723,7 +945,8 @@ func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.GraphObservations) > 0 && m.Cursor < len(m.GraphObservations) {
 			obsID := m.GraphObservations[m.Cursor].ID
 			m.PrevScreen = ScreenGraph
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "r":
 		// Re-root graph on selected observation
@@ -751,7 +974,38 @@ func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservation(m.deps, m.DeleteTargetID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.ArchivedObservations) > 0 {
+			m.Cursor = len(m.ArchivedObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -770,7 +1024,34 @@ func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
 			obsID := m.ArchivedObservations[m.Cursor].ID
 			m.PrevScreen = ScreenArchive
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+		}
+	case "u":
+		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
+			obs := m.ArchivedObservations[m.Cursor]
+			return m, unarchiveObservation(m.deps, obs.ID)
+		}
+	case "d":
+		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
+			obs := m.ArchivedObservations[m.Cursor]
+			m.ConfirmDelete = true
+			m.DeleteTargetID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, loadArchivedObservations(m.deps, m.FilterProject)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard
@@ -794,6 +1075,13 @@ func (m Model) handleHealthKeys(key string) (tea.Model, tea.Cmd) {
 		if m.Scroll > maxScrollOffset {
 			m.Scroll = maxScrollOffset
 		}
+	case "tab":
+		m.HealthSection = (m.HealthSection + 1) % 3
+		m.HealthExpanded = false
+		m.Scroll = 0
+	case "enter":
+		m.HealthExpanded = !m.HealthExpanded
+		m.Scroll = 0
 	case "esc", "q":
 		m.Screen = ScreenDashboard
 		m.Cursor = 0
@@ -962,17 +1250,21 @@ func (m Model) handleEmbeddingConfigKeys(key string) (tea.Model, tea.Cmd) {
 	case "left", "h":
 		if m.EmbCfgFocusField == 0 {
 			m.EmbCfgProvider = (m.EmbCfgProvider + 2) % 3 // cycle left
+			m.EmbCfgDirty = true
 		}
 	case "right", "l":
 		if m.EmbCfgFocusField == 0 {
 			m.EmbCfgProvider = (m.EmbCfgProvider + 1) % 3 // cycle right
+			m.EmbCfgDirty = true
 		}
 	case " ":
 		switch m.EmbCfgFocusField {
 		case 2:
 			m.EmbCfgVector = !m.EmbCfgVector
+			m.EmbCfgDirty = true
 		case 3:
 			m.EmbCfgAutoStart = !m.EmbCfgAutoStart
+			m.EmbCfgDirty = true
 		}
 	case "enter":
 		switch m.EmbCfgFocusField {
@@ -1003,11 +1295,11 @@ func (m Model) refreshScreen(screen Screen) tea.Cmd {
 	case ScreenDashboard:
 		return loadStats(m.deps)
 	case ScreenRecent:
-		return loadRecentObservations(m.deps)
+		return loadRecentObservations(m.deps, m.FilterProject)
 	case ScreenSessions:
 		return loadRecentSessions(m.deps)
 	case ScreenArchive:
-		return loadArchivedObservations(m.deps)
+		return loadArchivedObservations(m.deps, m.FilterProject)
 	default:
 		return nil
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -90,6 +90,15 @@ func (m Model) View() string {
 		content += "\n" + errorStyle.Render("Error: "+m.ErrorMsg)
 	}
 
+	if m.ConfirmDelete {
+		title := m.DeleteTargetTitle
+		if len(title) > 40 {
+			title = title[:40] + "..."
+		}
+		overlay := fmt.Sprintf("\n  Delete %q? (y/n)", title)
+		content += "\n" + lipgloss.NewStyle().Foreground(colorAmber).Bold(true).Render(overlay)
+	}
+
 	return appStyle.Render(content)
 }
 
@@ -192,6 +201,9 @@ func (m Model) viewSearchResults() string {
 	if resultCount != 1 {
 		header += "s"
 	}
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -212,9 +224,16 @@ func (m Model) viewSearchResults() string {
 		end = resultCount
 	}
 
+	scoreStyle := lipgloss.NewStyle().Foreground(colorSubtext)
 	for i := m.Scroll; i < end; i++ {
 		r := m.SearchResults[i]
 		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, nil))
+		scoreInfo := fmt.Sprintf("     score: %.0f%%", r.Rank*100)
+		if r.ScoreBreakdown.Strategy != "" {
+			scoreInfo += fmt.Sprintf("  strategy: %s", r.ScoreBreakdown.Strategy)
+		}
+		b.WriteString(scoreStyle.Render(scoreInfo))
+		b.WriteString("\n")
 	}
 
 	if resultCount > visibleItems {
@@ -222,7 +241,7 @@ func (m Model) viewSearchResults() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, resultCount)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • / search • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • / search • esc back"))
 
 	return b.String()
 }
@@ -234,6 +253,9 @@ func (m Model) viewRecent() string {
 
 	count := len(m.RecentObservations)
 	header := fmt.Sprintf("  Recent Observations — %d total", count)
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -264,7 +286,7 @@ func (m Model) viewRecent() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • esc back"))
 
 	return b.String()
 }
@@ -277,7 +299,11 @@ func (m Model) viewObservationDetail() string {
 	if m.SelectedObservation == nil {
 		b.WriteString(headerStyle.Render("  Observation Detail"))
 		b.WriteString("\n")
-		b.WriteString(noResultsStyle.Render("Loading..."))
+		if m.DetailLoading {
+			b.WriteString(noResultsStyle.Render(m.SetupSpinner.View() + " Loading observation..."))
+		} else {
+			b.WriteString(noResultsStyle.Render("Loading..."))
+		}
 		return b.String()
 	}
 
@@ -390,7 +416,7 @@ func (m Model) viewObservationDetail() string {
 			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", scroll+1, end, len(contentLines))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • g graph • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • g graph • s session • d delete • esc back"))
 
 	return b.String()
 }
@@ -794,6 +820,9 @@ func (m Model) viewArchive() string {
 
 	count := len(m.ArchivedObservations)
 	header := fmt.Sprintf("  Archived Observations — %d total", count)
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -824,7 +853,7 @@ func (m Model) viewArchive() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • u unarchive • d delete • f filter • esc back"))
 
 	return b.String()
 }
@@ -861,16 +890,28 @@ func (m Model) viewHealth() string {
 	b.WriteString(statCardStyle.Render(statsContent))
 	b.WriteString("\n")
 
-	// Stale observations
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Stale Observations (%d)", len(m.HealthStale))))
+	// Section focus marker
+	sectionMarker := func(section int) string {
+		if m.HealthSection == section {
+			return "▸ "
+		}
+		return "  "
+	}
+
+	// Stale observations (section 0)
+	staleLimit := 5
+	if m.HealthSection == 0 && m.HealthExpanded {
+		staleLimit = len(m.HealthStale)
+	}
+	b.WriteString(sectionHeadingStyle.Render(sectionMarker(0) + fmt.Sprintf("Stale Observations (%d)", len(m.HealthStale))))
 	b.WriteString("\n")
 	if len(m.HealthStale) == 0 {
 		b.WriteString(listItemStyle.Render("  None — all high-score observations accessed recently"))
 		b.WriteString("\n")
 	} else {
 		for i, o := range m.HealthStale {
-			if i >= 5 {
-				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more", len(m.HealthStale)-5)))
+			if i >= staleLimit {
+				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more (enter to expand)", len(m.HealthStale)-staleLimit)))
 				break
 			}
 			fmt.Fprintf(&b, "  %s %s  %s\n",
@@ -881,16 +922,20 @@ func (m Model) viewHealth() string {
 	}
 	b.WriteString("\n")
 
-	// Orphan observations
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Orphan Observations (%d)", len(m.HealthOrphans))))
+	// Orphan observations (section 1)
+	orphanLimit := 5
+	if m.HealthSection == 1 && m.HealthExpanded {
+		orphanLimit = len(m.HealthOrphans)
+	}
+	b.WriteString(sectionHeadingStyle.Render(sectionMarker(1) + fmt.Sprintf("Orphan Observations (%d)", len(m.HealthOrphans))))
 	b.WriteString("\n")
 	if len(m.HealthOrphans) == 0 {
 		b.WriteString(listItemStyle.Render("  None — all observations are connected via graph"))
 		b.WriteString("\n")
 	} else {
 		for i, o := range m.HealthOrphans {
-			if i >= 5 {
-				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more", len(m.HealthOrphans)-5)))
+			if i >= orphanLimit {
+				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more (enter to expand)", len(m.HealthOrphans)-orphanLimit)))
 				break
 			}
 			fmt.Fprintf(&b, "  %s %s  %s\n",
@@ -901,15 +946,20 @@ func (m Model) viewHealth() string {
 	}
 	b.WriteString("\n")
 
-	// Consolidation candidates
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Consolidation Candidates (%d)", len(m.HealthCandidates))))
+	// Consolidation candidates (section 2)
+	candidateLimit := 8
+	if m.HealthSection == 2 && m.HealthExpanded {
+		candidateLimit = len(m.HealthCandidates)
+	}
+	b.WriteString(sectionHeadingStyle.Render(sectionMarker(2) + fmt.Sprintf("Consolidation Candidates (%d)", len(m.HealthCandidates))))
 	b.WriteString("\n")
 	if len(m.HealthCandidates) == 0 {
 		b.WriteString(listItemStyle.Render("  None — no duplicate topic keys found"))
 		b.WriteString("\n")
 	} else {
 		for i, c := range m.HealthCandidates {
-			if i >= 8 {
+			if i >= candidateLimit {
+				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more (enter to expand)", len(m.HealthCandidates)-candidateLimit)))
 				break
 			}
 			fmt.Fprintf(&b, "  %-40s  %s\n",
@@ -918,7 +968,7 @@ func (m Model) viewHealth() string {
 		}
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k scroll • tab section • enter expand/collapse • esc back"))
 
 	return b.String()
 }
@@ -997,7 +1047,13 @@ func (m Model) viewEmbeddingConfig() string {
 	var b strings.Builder
 
 	b.WriteString(headerStyle.Render("  Embedding Settings"))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	if m.EmbCfgDirty {
+		b.WriteString("  " + lipgloss.NewStyle().Foreground(colorAmber).Render("* Unsaved changes"))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
 
 	providers := []string{"none", "ollama", "openai"}
 	focusMarker := func(field int) string {


### PR DESCRIPTION
## Summary
- Fix critical hybrid search bugs causing silent failures with embeddings enabled
- Add 9 TUI improvements for better UX across all screens

### Search Fixes
- **Race condition**: Add mutex to `ollamaService`/`openAIService` dims cache — concurrent `Embed()` calls were racing on dimension caching
- **Silent errors**: Log embedding failures in `mem_save` goroutine and hybrid search instead of swallowing
- **Wrong fallback**: Remove semantically incorrect fallback that used first FTS5 result's embedding as query proxy
- **Dimension warnings**: Log dimension mismatches in cosine similarity instead of returning silent 0
- **Dynamic dims**: Add dynamic dimension caching to OpenAI service (was hardcoded 1536)
- **Stale docs**: Fix documentation claiming 384 dimensions (actual: 64-4096)

### TUI Improvements
- **Loading spinners**: Animated spinner in observation detail view while loading
- **Search scores**: Show rank % and strategy (keyword/hybrid) in search results
- **Project filter**: `f` key cycles through projects on SearchResults, Recent, Archive
- **Delete**: `d` key with `y/n` confirmation on all observation screens (soft delete)
- **Unarchive**: `u` key on Archive screen + new `Restore()` store method
- **Health expand**: `tab` to cycle sections, `enter` to expand/collapse (was limited to 5 items)
- **Search history**: Up/down arrows cycle through previous queries (max 20)
- **Obs→Session nav**: `s` key in detail view jumps to session
- **Vim keys**: `G` (bottom), `gg` (top) on all list screens
- **Dirty indicator**: Amber "* Unsaved changes" on embedding config screen

## Test plan
- [x] `go build -tags cortex_vectors ./cmd/cortex` compiles
- [x] All existing tests pass (67 TUI tests, embedding, MCP, store, config, ollama)
- [ ] Manual: search with Ollama → scores displayed, filter by project works
- [ ] Manual: delete observation → confirmation → refreshes list
- [ ] Manual: archive screen → `u` unarchives → observation returns to recent
- [ ] Manual: health → tab sections → enter expands stale/orphan lists
- [ ] Manual: search → up arrow → previous query recalled