### PR TITLE
feat: hybrid search fixes + comprehensive TUI overhaul

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -575,7 +575,7 @@ func runTUI(stdout, stderr io.Writer) int {
 	}
 
 	model := tui.New(deps)
-	p := tea.NewProgram(model)
+	p := tea.NewProgram(model, tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		writef(stderr, "cortex: %v\n", err)
 		return 1

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -137,7 +137,7 @@ type ScoringRepository interface {
 
 // VectorSearchOptions provides options for vector similarity search.
 type VectorSearchOptions struct {
-	// Embedding is the query embedding vector (384 dimensions).
+	// Embedding is the query embedding vector (64-4096 dimensions depending on model).
 	Embedding []float32
 	// Limit is the maximum number of results to return.
 	Limit int
@@ -163,7 +163,7 @@ type VectorSearchResult struct {
 // When not enabled, all methods return ErrVectorSearchDisabled.
 type VectorRepository interface {
 	// StoreEmbedding stores an embedding vector for an observation.
-	// The embedding must have exactly 384 dimensions.
+	// The embedding dimensions must be between 64 and 4096.
 	// Returns an error if the observation doesn't exist or embedding dimension is wrong.
 	StoreEmbedding(ctx context.Context, observationID int64, embedding []float32, model string) error
 

--- a/internal/embedding/service.go
+++ b/internal/embedding/service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -77,6 +78,7 @@ type ollamaService struct {
 	baseURL string
 	model   string
 	dims    int // cached after first call
+	mu      sync.Mutex
 }
 
 func (s *ollamaService) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -122,14 +124,18 @@ func (s *ollamaService) Embed(ctx context.Context, text string) ([]float32, erro
 	}
 
 	// Cache dimensions from first result
+	s.mu.Lock()
 	if s.dims == 0 {
 		s.dims = len(vec)
 	}
+	s.mu.Unlock()
 
 	return vec, nil
 }
 
 func (s *ollamaService) Dimensions() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.dims > 0 {
 		return s.dims
 	}
@@ -144,6 +150,8 @@ func (s *ollamaService) Model() string { return s.model }
 type openAIService struct {
 	apiKey string
 	model  string
+	dims   int
+	mu     sync.Mutex
 }
 
 func (s *openAIService) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -183,8 +191,25 @@ func (s *openAIService) Embed(ctx context.Context, text string) ([]float32, erro
 		return nil, fmt.Errorf("openai: no data returned")
 	}
 
-	return result.Data[0].Embedding, nil
+	vec := result.Data[0].Embedding
+
+	// Cache dimensions from first result
+	s.mu.Lock()
+	if s.dims == 0 {
+		s.dims = len(vec)
+	}
+	s.mu.Unlock()
+
+	return vec, nil
 }
 
-func (s *openAIService) Dimensions() int { return 1536 }
+func (s *openAIService) Dimensions() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.dims > 0 {
+		return s.dims
+	}
+	// Default for text-embedding-3-small
+	return 1536
+}
 func (s *openAIService) Model() string   { return s.model }

--- a/internal/mcp/tools_cortex.go
+++ b/internal/mcp/tools_cortex.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"time"
@@ -385,12 +386,11 @@ func handleSearchHybrid(stores *Stores) server.ToolHandlerFunc {
 
 			// Prefer generating a real query embedding via the embedding service
 			if stores.Embeddings != nil {
-				queryVec, _ = stores.Embeddings.Embed(ctx, query)
-			}
-
-			// Fallback: use first FTS5 result's stored embedding as proxy
-			if len(queryVec) == 0 && len(ftsResults) > 0 {
-				queryVec, _, _ = stores.Vectors.GetEmbedding(ctx, ftsResults[0].ID)
+				var embedErr error
+				queryVec, embedErr = stores.Embeddings.Embed(ctx, query)
+				if embedErr != nil {
+					log.Printf("warning: hybrid search embed failed, falling back to FTS5: %v", embedErr)
+				}
 			}
 
 			if len(queryVec) > 0 {

--- a/internal/mcp/tools_memory.go
+++ b/internal/mcp/tools_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -550,11 +551,18 @@ func handleSave(stores *Stores) server.ToolHandlerFunc {
 		// Auto-embed for vector search (best-effort, non-blocking)
 		if stores.Embeddings != nil && stores.Vectors != nil && stores.Vectors.IsAvailable() {
 			go func() {
-				bgCtx := context.Background()
+				bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
 				text := obs.Title + "\n" + obs.Content
 				vec, err := stores.Embeddings.Embed(bgCtx, text)
-				if err == nil && len(vec) > 0 {
-					_ = stores.Vectors.StoreEmbedding(bgCtx, obs.ID, vec, stores.Embeddings.Model())
+				if err != nil {
+					log.Printf("warning: auto-embed failed for obs %d: %v", obs.ID, err)
+					return
+				}
+				if len(vec) > 0 {
+					if storeErr := stores.Vectors.StoreEmbedding(bgCtx, obs.ID, vec, stores.Embeddings.Model()); storeErr != nil {
+						log.Printf("warning: store embedding failed for obs %d: %v", obs.ID, storeErr)
+					}
 				}
 			}()
 		}

--- a/internal/store/sqlite/memory_store.go
+++ b/internal/store/sqlite/memory_store.go
@@ -338,6 +338,35 @@ func (s *Store) HardDelete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// Restore restores a soft-deleted observation (alias for Unarchive).
+func (s *Store) Restore(ctx context.Context, id int64) error {
+	return s.Unarchive(ctx, id)
+}
+
+// Unarchive restores a soft-deleted observation by clearing its deleted_at field.
+// Returns ErrNotFound if the observation doesn't exist or is not archived.
+func (s *Store) Unarchive(ctx context.Context, id int64) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE observations
+		SET deleted_at = NULL, updated_at = datetime('now')
+		WHERE id = ? AND deleted_at IS NOT NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("memory store: unarchive observation: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("memory store: get rows affected: %w", err)
+	}
+
+	if affected == 0 {
+		return &domain.NotFoundError{Type: "observation", ID: id}
+	}
+
+	return nil
+}
+
 // ListArchivable retrieves observations older than cutoff with score below minScore.
 // Uses a JOIN with importance_scores to avoid N+1 queries during archival.
 func (s *Store) ListArchivable(ctx context.Context, cutoff time.Time, minScore float64, limit int) ([]*domain.Observation, error) {

--- a/internal/store/sqlite/vector_store_enabled.go
+++ b/internal/store/sqlite/vector_store_enabled.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"time"
@@ -43,7 +44,7 @@ func NewVectorStore(db *sql.DB) *VectorStore {
 }
 
 // StoreEmbedding stores an embedding vector for an observation.
-// The embedding must have exactly EmbeddingDimension (384) dimensions.
+// The embedding must have between MinEmbeddingDimension and MaxEmbeddingDimension dimensions.
 // The model parameter identifies the embedding model used (e.g., "all-MiniLM-L6-v2").
 func (s *VectorStore) StoreEmbedding(ctx context.Context, observationID int64, embedding []float32, model string) error {
 	// Validate embedding dimension (flexible — accept any reasonable size)
@@ -283,6 +284,7 @@ func normalizeVector(v []float32) []float64 {
 // Both vectors should be pre-normalized for efficiency.
 func cosineSimilarity(a []float64, b []float32) float64 {
 	if len(a) != len(b) {
+		log.Printf("warning: cosine similarity dimension mismatch: query=%d stored=%d", len(a), len(b))
 		return 0
 	}
 
@@ -314,6 +316,7 @@ func computeCosineSimilarity(queryNorm []float64, embedding []float32) float64 {
 
 	// Dot product of normalized vectors
 	if len(queryNorm) != len(embF64) {
+		log.Printf("warning: cosine similarity dimension mismatch: query=%d stored=%d", len(queryNorm), len(embF64))
 		return 0
 	}
 	var dot float64

--- a/internal/tui/items.go
+++ b/internal/tui/items.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/lleontor705/cortex/internal/domain"
+	"github.com/lleontor705/cortex/internal/store/session"
+)
+
+// observationItem wraps a domain.Observation for bubbles/list.
+type observationItem struct {
+	obs *domain.Observation
+}
+
+func (i observationItem) Title() string {
+	tColor := typeColor(i.obs.Type)
+	badge := lipgloss.NewStyle().Foreground(tColor).Bold(true).Render(fmt.Sprintf("[%s]", i.obs.Type))
+	return fmt.Sprintf("#%-5d %s %s", i.obs.ID, badge, truncateStr(i.obs.Title, 45))
+}
+
+func (i observationItem) Description() string {
+	desc := truncateStr(i.obs.Content, 80)
+	if i.obs.Project != "" {
+		desc = i.obs.Project + " | " + desc
+	}
+	return desc
+}
+
+func (i observationItem) FilterValue() string {
+	return i.obs.Title + " " + i.obs.Content + " " + i.obs.Type + " " + i.obs.Project
+}
+
+// searchResultItem wraps a SearchResult with score info.
+type searchResultItem struct {
+	result *domain.SearchResult
+}
+
+func (i searchResultItem) Title() string {
+	tColor := typeColor(i.result.Type)
+	badge := lipgloss.NewStyle().Foreground(tColor).Bold(true).Render(fmt.Sprintf("[%s]", i.result.Type))
+	score := fmt.Sprintf("%.0f%%", i.result.Rank*100)
+	return fmt.Sprintf("#%-5d %s %s  %s", i.result.ID, badge, truncateStr(i.result.Title, 40), score)
+}
+
+func (i searchResultItem) Description() string {
+	desc := truncateStr(i.result.Content, 80)
+	if i.result.ScoreBreakdown.Strategy != "" {
+		desc = i.result.ScoreBreakdown.Strategy + " | " + desc
+	}
+	return desc
+}
+
+func (i searchResultItem) FilterValue() string {
+	return i.result.Title + " " + i.result.Content
+}
+
+// sessionItem wraps session stats.
+type sessionItem struct {
+	session *session.SessionStats
+}
+
+func (i sessionItem) Title() string {
+	return fmt.Sprintf("%-20s  %d observations", i.session.Session.Project, i.session.ObservationCount)
+}
+
+func (i sessionItem) Description() string {
+	desc := formatTime(i.session.Session.StartedAt)
+	if i.session.Session.Summary != "" {
+		desc += " | " + truncateStr(i.session.Session.Summary, 50)
+	}
+	return desc
+}
+
+func (i sessionItem) FilterValue() string {
+	return i.session.Session.Project + " " + i.session.Session.Summary
+}
+
+// graphItem wraps an observation with edge info.
+type graphItem struct {
+	obs       *domain.Observation
+	edgeLabel string
+}
+
+func (i graphItem) Title() string {
+	tColor := typeColor(i.obs.Type)
+	badge := lipgloss.NewStyle().Foreground(tColor).Bold(true).Render(fmt.Sprintf("[%s]", i.obs.Type))
+	title := fmt.Sprintf("#%-5d %s %s", i.obs.ID, badge, truncateStr(i.obs.Title, 40))
+	if i.edgeLabel != "" {
+		title += "  " + graphEdgeStyle.Render("["+i.edgeLabel+"]")
+	}
+	return title
+}
+
+func (i graphItem) Description() string {
+	return truncateStr(i.obs.Content, 70)
+}
+
+func (i graphItem) FilterValue() string {
+	return i.obs.Title + " " + i.obs.Content
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,8 +7,10 @@ import (
 	"github.com/lleontor705/cortex/internal/store/session"
 	"github.com/lleontor705/cortex/internal/update"
 
+	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -150,7 +152,14 @@ type configReloadedMsg struct {
 type reindexProgressMsg struct {
 	progress string
 	done     bool
+	total    int
+	indexed  int
 	err      error
+}
+
+type activityDataMsg struct {
+	daily []int // observation counts per day, last 7 days (index 0 = 6 days ago, index 6 = today)
+	err   error
 }
 
 type deleteObservationMsg struct {
@@ -201,7 +210,7 @@ type Model struct {
 	DetailScore         *domain.ImportanceScore
 	DetailEntities      []*domain.EntityLink
 	DetailEdges         []*domain.Edge
-	DetailScroll        int
+	DetailViewport      viewport.Model
 	DetailLoading       bool
 
 	// Timeline
@@ -274,6 +283,15 @@ type Model struct {
 	EmbCfgReindexWarning   bool
 	EmbCfgReindexing       bool
 	EmbCfgReindexProgress  string
+	ReindexProgressBar     progress.Model
+	ReindexTotal           int
+	ReindexDone            int
+
+	// Activity sparkline (7-day observation counts)
+	ActivityData []int
+
+	// Focus management (for future split pane)
+	FocusedPane int // 0=main, 1=preview (for future split pane)
 
 	// Toast messages
 	ToastMessage string
@@ -283,6 +301,11 @@ type Model struct {
 	ConfirmDelete     bool
 	ConfirmDeleteID   int64
 	DeleteTargetTitle string
+
+	// Command palette
+	CmdPaletteOpen   bool
+	CmdPaletteInput  textinput.Model
+	CmdPaletteCursor int
 }
 
 // New creates a new TUI model connected to the given stores.
@@ -305,6 +328,11 @@ func New(deps *Deps) Model {
 	embModel.CharLimit = 128
 	embModel.Width = 40
 
+	cmdInput := textinput.New()
+	cmdInput.Placeholder = "Type a command..."
+	cmdInput.CharLimit = 64
+	cmdInput.Width = 40
+
 	// Initialize embedding config from current config if available
 	embProvider := 0
 	embVector := false
@@ -322,16 +350,18 @@ func New(deps *Deps) Model {
 	}
 
 	return Model{
-		deps:            deps,
-		Version:         deps.Version,
-		Screen:          ScreenDashboard,
-		SearchInput:     ti,
-		SetupSpinner:    sp,
-		EmbCfgSpinner:   embSp,
-		EmbCfgModel:     embModel,
-		EmbCfgProvider:   embProvider,
-		EmbCfgVector:     embVector,
-		EmbCfgAutoStart:  embAutoStart,
+		deps:               deps,
+		Version:            deps.Version,
+		Screen:             ScreenDashboard,
+		SearchInput:        ti,
+		SetupSpinner:       sp,
+		EmbCfgSpinner:      embSp,
+		EmbCfgModel:        embModel,
+		EmbCfgProvider:     embProvider,
+		EmbCfgVector:       embVector,
+		EmbCfgAutoStart:    embAutoStart,
+		ReindexProgressBar: progress.New(progress.WithDefaultGradient()),
+		CmdPaletteInput:    cmdInput,
 	}
 }
 
@@ -339,6 +369,7 @@ func New(deps *Deps) Model {
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		loadStats(m.deps),
+		loadActivityData(m.deps),
 		checkForUpdate(m.Version),
 		tea.EnterAltScreen,
 	)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lleontor705/cortex/internal/store/session"
 	"github.com/lleontor705/cortex/internal/update"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -290,8 +291,10 @@ type Model struct {
 	// Activity sparkline (7-day observation counts)
 	ActivityData []int
 
-	// Focus management (for future split pane)
-	FocusedPane int // 0=main, 1=preview (for future split pane)
+	// Split pane preview
+	PreviewVisible  bool
+	PreviewViewport viewport.Model
+	FocusedPane     int // 0=main, 1=preview
 
 	// Toast messages
 	ToastMessage string
@@ -306,6 +309,13 @@ type Model struct {
 	CmdPaletteOpen   bool
 	CmdPaletteInput  textinput.Model
 	CmdPaletteCursor int
+
+	// List components (bubbles/list)
+	SearchListModel  list.Model
+	RecentList       list.Model
+	SessionListModel list.Model
+	GraphListModel   list.Model
+	ArchiveList      list.Model
 }
 
 // New creates a new TUI model connected to the given stores.
@@ -349,6 +359,17 @@ func New(deps *Deps) Model {
 		embAutoStart = deps.Config.Search.OllamaAutoStart
 	}
 
+	// Create empty list models with default delegate
+	newEmptyList := func() list.Model {
+		l := list.New(nil, list.NewDefaultDelegate(), 0, 0)
+		l.SetShowHelp(false)
+		l.SetShowStatusBar(false)
+		l.SetShowTitle(false)
+		l.DisableQuitKeybindings()
+		l.SetFilteringEnabled(true)
+		return l
+	}
+
 	return Model{
 		deps:               deps,
 		Version:            deps.Version,
@@ -362,6 +383,11 @@ func New(deps *Deps) Model {
 		EmbCfgAutoStart:    embAutoStart,
 		ReindexProgressBar: progress.New(progress.WithDefaultGradient()),
 		CmdPaletteInput:    cmdInput,
+		SearchListModel:    newEmptyList(),
+		RecentList:         newEmptyList(),
+		SessionListModel:   newEmptyList(),
+		GraphListModel:     newEmptyList(),
+		ArchiveList:        newEmptyList(),
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -32,6 +32,7 @@ const (
 	ScreenArchive
 	ScreenHealth
 	ScreenEmbeddingConfig
+	ScreenHelp
 )
 
 // ─── Aggregate types ────────────────────────────────────────────────────────
@@ -146,6 +147,22 @@ type configReloadedMsg struct {
 	err error
 }
 
+type reindexProgressMsg struct {
+	progress string
+	done     bool
+	err      error
+}
+
+type deleteObservationMsg struct {
+	id  int64
+	err error
+}
+
+type unarchiveObservationMsg struct {
+	id  int64
+	err error
+}
+
 // ─── Model ──────────────────────────────────────────────────────────────────
 
 // Model holds the TUI state.
@@ -170,9 +187,11 @@ type Model struct {
 	Stats *combinedStats
 
 	// Search
-	SearchInput   textinput.Model
-	SearchQuery   string
-	SearchResults []*domain.SearchResult
+	SearchInput      textinput.Model
+	SearchQuery      string
+	SearchResults    []*domain.SearchResult
+	SearchHistory    []string
+	SearchHistoryIdx int
 
 	// Recent observations
 	RecentObservations []*domain.Observation
@@ -183,6 +202,7 @@ type Model struct {
 	DetailEntities      []*domain.EntityLink
 	DetailEdges         []*domain.Edge
 	DetailScroll        int
+	DetailLoading       bool
 
 	// Timeline
 	TimelineFocus  *domain.Observation
@@ -200,6 +220,13 @@ type Model struct {
 	GraphEdges        []*domain.Edge
 	GraphRootID       int64
 
+	// List filtering
+	FilterProject string // active project filter ("" = all)
+	FilterActive  bool   // whether filter is shown
+
+	// Vim multi-key sequences
+	PendingKey string // for multi-key sequences like "gg"
+
 	// Archive (Cortex-exclusive)
 	ArchivedObservations []*domain.Observation
 
@@ -209,6 +236,8 @@ type Model struct {
 	HealthEdgeCount  int
 	HealthObsCount   int
 	HealthCandidates []healthCandidate
+	HealthSection    int  // 0=stale, 1=orphans, 2=candidates
+	HealthExpanded   bool
 
 	// Setup
 	SetupAgents           []setup.Agent
@@ -223,6 +252,7 @@ type Model struct {
 	SetupSpinner          spinner.Model
 
 	// Embedding config
+	EmbCfgDirty          bool
 	EmbCfgProvider       int             // 0=none, 1=ollama, 2=openai
 	EmbCfgModel          textinput.Model // model name input
 	EmbCfgVector         bool            // vector search toggle
@@ -237,6 +267,22 @@ type Model struct {
 	EmbCfgPulling        bool
 	EmbCfgStarting       bool
 	EmbCfgSpinner        spinner.Model
+
+	// Embedding config — provider/model change detection
+	EmbCfgOriginalProvider int
+	EmbCfgOriginalModel    string
+	EmbCfgReindexWarning   bool
+	EmbCfgReindexing       bool
+	EmbCfgReindexProgress  string
+
+	// Toast messages
+	ToastMessage string
+	ToastType    string // "success", "warning", "error"
+
+	// Delete confirmation
+	ConfirmDelete     bool
+	ConfirmDeleteID   int64
+	DeleteTargetTitle string
 }
 
 // New creates a new TUI model connected to the given stores.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -356,7 +356,7 @@ func TestLoadStatsWithNilObservations(t *testing.T) {
 }
 
 func TestLoadSearchWithNilDeps(t *testing.T) {
-	cmd := searchMemories(nil, "test")
+	cmd := searchMemories(nil, "test", "")
 	msg := cmd()
 	loaded, ok := msg.(searchResultsMsg)
 	if !ok {

--- a/internal/tui/store.go
+++ b/internal/tui/store.go
@@ -94,24 +94,24 @@ func loadStats(d *Deps) tea.Cmd {
 	}
 }
 
-func searchMemories(d *Deps, query string) tea.Cmd {
+func searchMemories(d *Deps, query string, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Search == nil {
 			return searchResultsMsg{err: fmt.Errorf("search store not available")}
 		}
 		ctx := context.Background()
-		results, err := d.Search.Search(ctx, query, domain.SearchOptions{Limit: 50})
+		results, err := d.Search.Search(ctx, query, domain.SearchOptions{Limit: 50, Project: project})
 		return searchResultsMsg{results: results, query: query, err: err}
 	}
 }
 
-func loadRecentObservations(d *Deps) tea.Cmd {
+func loadRecentObservations(d *Deps, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Observations == nil {
 			return recentObservationsMsg{err: fmt.Errorf("observations store not available")}
 		}
 		ctx := context.Background()
-		obs, err := d.Observations.List(ctx, domain.ObservationFilter{Limit: 50})
+		obs, err := d.Observations.List(ctx, domain.ObservationFilter{Limit: 50, Project: project})
 		return recentObservationsMsg{observations: obs, err: err}
 	}
 }
@@ -249,7 +249,7 @@ func loadGraphRelated(d *Deps, obsID int64) tea.Cmd {
 	}
 }
 
-func loadArchivedObservations(d *Deps) tea.Cmd {
+func loadArchivedObservations(d *Deps, project string) tea.Cmd {
 	return func() tea.Msg {
 		if d == nil || d.Observations == nil {
 			return archiveLoadedMsg{err: fmt.Errorf("observations store not available")}
@@ -258,6 +258,7 @@ func loadArchivedObservations(d *Deps) tea.Cmd {
 		obs, err := d.Observations.List(ctx, domain.ObservationFilter{
 			Limit:           50,
 			IncludeArchived: true,
+			Project:         project,
 		})
 		return archiveLoadedMsg{observations: obs, err: err}
 	}
@@ -379,6 +380,73 @@ func pullOllamaModelCmd(baseURL, model string) tea.Cmd {
 		mgr := ollama.NewManager(baseURL)
 		err := mgr.PullModel(ctx, model, nil)
 		return ollamaPullMsg{done: true, err: err}
+	}
+}
+
+func deleteObservationCmd(d *Deps, id int64) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Observations == nil {
+			return deleteObservationMsg{id: id, err: fmt.Errorf("observations store not available")}
+		}
+		ctx := context.Background()
+		err := d.Observations.SoftDelete(ctx, id)
+		return deleteObservationMsg{id: id, err: err}
+	}
+}
+
+func unarchiveObservationCmd(d *Deps, id int64) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Observations == nil {
+			return unarchiveObservationMsg{id: id, err: fmt.Errorf("observations store not available")}
+		}
+		ctx := context.Background()
+		err := d.Observations.Unarchive(ctx, id)
+		return unarchiveObservationMsg{id: id, err: err}
+	}
+}
+
+func startReindexCmd(d *Deps) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.App == nil {
+			return reindexProgressMsg{done: true, err: fmt.Errorf("app not available")}
+		}
+
+		// Reload config to pick up new provider/model
+		if err := d.App.ReloadConfig(); err != nil {
+			return reindexProgressMsg{done: true, err: fmt.Errorf("reload config: %w", err)}
+		}
+		d.Config = d.App.Config
+
+		if d.App.Stores.Embeddings == nil {
+			return reindexProgressMsg{done: true, err: fmt.Errorf("no embedding provider configured")}
+		}
+		if d.App.Stores.Vectors == nil || !d.App.Stores.Vectors.IsAvailable() {
+			return reindexProgressMsg{done: true, err: fmt.Errorf("vector store not available (build with -tags cortex_vectors)")}
+		}
+
+		ctx := context.Background()
+		obs, err := d.Observations.List(ctx, domain.ObservationFilter{Limit: 5000})
+		if err != nil {
+			return reindexProgressMsg{done: true, err: fmt.Errorf("list observations: %w", err)}
+		}
+
+		indexed, errCount := 0, 0
+		for _, o := range obs {
+			text := o.Title + "\n" + o.Content
+			vec, embErr := d.App.Stores.Embeddings.Embed(ctx, text)
+			if embErr != nil {
+				errCount++
+				continue
+			}
+			if storeErr := d.App.Stores.Vectors.StoreEmbedding(ctx, o.ID, vec, d.App.Stores.Embeddings.Model()); storeErr != nil {
+				errCount++
+				continue
+			}
+			indexed++
+		}
+
+		progress := fmt.Sprintf("Reindexed %d/%d observations (%d errors)", indexed, len(obs), errCount)
+		return reindexProgressMsg{progress: progress, done: true}
 	}
 }
 

--- a/internal/tui/store.go
+++ b/internal/tui/store.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/lleontor705/cortex/internal/app"
 	"github.com/lleontor705/cortex/internal/config"
@@ -91,6 +92,28 @@ func loadStats(d *Deps) tea.Cmd {
 				ByType:            stats.ByType,
 			},
 		}
+	}
+}
+
+func loadActivityData(d *Deps) tea.Cmd {
+	return func() tea.Msg {
+		if d == nil || d.Observations == nil {
+			return activityDataMsg{daily: make([]int, 7)}
+		}
+		ctx := context.Background()
+		daily := make([]int, 7)
+		now := time.Now()
+		for i := 0; i < 7; i++ {
+			dayStart := time.Date(now.Year(), now.Month(), now.Day()-6+i, 0, 0, 0, 0, now.Location())
+			dayEnd := dayStart.Add(24 * time.Hour)
+			obs, _ := d.Observations.List(ctx, domain.ObservationFilter{
+				CreatedAfter:  &dayStart,
+				CreatedBefore: &dayEnd,
+				Limit:         1000,
+			})
+			daily[i] = len(obs)
+		}
+		return activityDataMsg{daily: daily}
 	}
 }
 
@@ -446,7 +469,7 @@ func startReindexCmd(d *Deps) tea.Cmd {
 		}
 
 		progress := fmt.Sprintf("Reindexed %d/%d observations (%d errors)", indexed, len(obs), errCount)
-		return reindexProgressMsg{progress: progress, done: true}
+		return reindexProgressMsg{progress: progress, done: true, total: len(obs), indexed: indexed}
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -178,33 +178,6 @@ var (
 // ─── Cortex-Exclusive Styles ────────────────────────────────────────────────
 
 var (
-	// Importance score badge (color varies by score range)
-	scoreBadgeHighStyle = lipgloss.NewStyle().
-				Foreground(colorGold).
-				Bold(true)
-
-	scoreBadgeMidStyle = lipgloss.NewStyle().
-				Foreground(colorTeal)
-
-	scoreBadgeLowStyle = lipgloss.NewStyle().
-				Foreground(colorSubtext)
-
-	// Entity link type pills
-	entityFileStyle = lipgloss.NewStyle().
-			Foreground(colorBlue)
-
-	entityURLStyle = lipgloss.NewStyle().
-			Foreground(colorCyan)
-
-	entityPackageStyle = lipgloss.NewStyle().
-				Foreground(colorGreen)
-
-	entitySymbolStyle = lipgloss.NewStyle().
-				Foreground(colorPurple)
-
-	entityDefaultStyle = lipgloss.NewStyle().
-				Foreground(colorSubtext)
-
 	// Graph edge relationship badges
 	graphEdgeStyle = lipgloss.NewStyle().
 			Foreground(colorMauve).
@@ -216,18 +189,6 @@ var (
 			Italic(true)
 )
 
-// scoreStyle returns the appropriate style for an importance score.
-func scoreStyle(score float64) lipgloss.Style {
-	switch {
-	case score >= 3.0:
-		return scoreBadgeHighStyle
-	case score >= 1.5:
-		return scoreBadgeMidStyle
-	default:
-		return scoreBadgeLowStyle
-	}
-}
-
 // ─── Status Bar & Toast Styles ──────────────────────────────────────────────
 
 var (
@@ -236,11 +197,6 @@ var (
 			Background(lipgloss.Color("#1a1b2e")).
 			Padding(0, 1)
 
-	modalStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorRed).
-			Padding(1, 2).
-			MarginTop(1)
 )
 
 // typeColor returns a lipgloss.Color for observation types.
@@ -265,18 +221,3 @@ func typeColor(obsType string) lipgloss.Color {
 	}
 }
 
-// entityStyle returns the style for an entity type.
-func entityStyle(entityType string) lipgloss.Style {
-	switch entityType {
-	case "file":
-		return entityFileStyle
-	case "url":
-		return entityURLStyle
-	case "package":
-		return entityPackageStyle
-	case "symbol":
-		return entitySymbolStyle
-	default:
-		return entityDefaultStyle
-	}
-}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -76,7 +76,8 @@ var (
 			PaddingLeft(2)
 
 	menuSelectedStyle = lipgloss.NewStyle().
-				Foreground(colorCyan).
+				Background(colorCyan).
+				Foreground(lipgloss.Color("#16161e")).
 				Bold(true).
 				PaddingLeft(1)
 
@@ -94,7 +95,8 @@ var (
 			PaddingLeft(2)
 
 	listSelectedStyle = lipgloss.NewStyle().
-				Foreground(colorCyan).
+				Background(colorCyan).
+				Foreground(lipgloss.Color("#16161e")).
 				Bold(true).
 				PaddingLeft(1)
 
@@ -223,6 +225,43 @@ func scoreStyle(score float64) lipgloss.Style {
 		return scoreBadgeMidStyle
 	default:
 		return scoreBadgeLowStyle
+	}
+}
+
+// ─── Status Bar & Toast Styles ──────────────────────────────────────────────
+
+var (
+	statusBarStyle = lipgloss.NewStyle().
+			Foreground(colorText).
+			Background(lipgloss.Color("#1a1b2e")).
+			Padding(0, 1)
+
+	modalStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorRed).
+			Padding(1, 2).
+			MarginTop(1)
+)
+
+// typeColor returns a lipgloss.Color for observation types.
+func typeColor(obsType string) lipgloss.Color {
+	switch obsType {
+	case "bugfix":
+		return colorRed
+	case "decision":
+		return colorCyan
+	case "architecture":
+		return colorPurple
+	case "discovery":
+		return colorTeal
+	case "pattern":
+		return colorBlue
+	case "config":
+		return colorAmber
+	case "preference":
+		return colorGold
+	default:
+		return colorSubtext
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -138,8 +138,6 @@ var (
 				Align(lipgloss.Right).
 				PaddingRight(1)
 
-	detailValueStyle = lipgloss.NewStyle().
-				Foreground(colorText)
 )
 
 // ─── Timeline Styles ─────────────────────────────────────────────────────────
@@ -183,10 +181,6 @@ var (
 			Foreground(colorMauve).
 			Bold(true)
 
-	// Archived observation dimmed style
-	archivedStyle = lipgloss.NewStyle().
-			Foreground(colorSubtext).
-			Italic(true)
 )
 
 // ─── Status Bar & Toast Styles ──────────────────────────────────────────────

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/lleontor705/cortex/internal/setup"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -38,6 +39,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.DetailViewport.Width = w
 			m.DetailViewport.Height = h
 		}
+		// Preview pane: disable if too narrow, resize if visible
+		if m.Width < 100 {
+			m.PreviewVisible = false
+		}
+		if m.PreviewVisible {
+			m.PreviewViewport.Width = m.Width*3/5 - 6
+			m.PreviewViewport.Height = m.Height - 10
+		}
+
+		// Resize all list components
+		w := msg.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		if m.PreviewVisible {
+			listWidth := m.Width * 2 / 5
+			m.SearchListModel.SetSize(listWidth-4, msg.Height-10)
+			m.RecentList.SetSize(listWidth-4, msg.Height-8)
+		} else {
+			m.SearchListModel.SetSize(w, msg.Height-10)
+			m.RecentList.SetSize(w, msg.Height-8)
+		}
+		m.SessionListModel.SetSize(w, msg.Height-8)
+		m.GraphListModel.SetSize(w, msg.Height-12)
+		m.ArchiveList.SetSize(w, msg.Height-8)
 		return m, nil
 
 	case tea.KeyMsg:
@@ -54,7 +80,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenEmbeddingConfig && m.EmbCfgModel.Focused() {
 			return m.handleEmbeddingModelInput(msg)
 		}
-		return m.handleKeyPress(msg.String())
+
+		// For list screens, pass key messages to list component for navigation
+		var listCmd tea.Cmd
+		switch m.Screen {
+		case ScreenSearchResults:
+			if !m.ConfirmDelete {
+				m.SearchListModel, listCmd = m.SearchListModel.Update(msg)
+			}
+		case ScreenRecent:
+			if !m.ConfirmDelete {
+				m.RecentList, listCmd = m.RecentList.Update(msg)
+			}
+		case ScreenSessions:
+			m.SessionListModel, listCmd = m.SessionListModel.Update(msg)
+		case ScreenGraph:
+			m.GraphListModel, listCmd = m.GraphListModel.Update(msg)
+		case ScreenArchive:
+			if !m.ConfirmDelete {
+				m.ArchiveList, listCmd = m.ArchiveList.Update(msg)
+			}
+		}
+
+		// Update preview content if visible (cursor may have changed)
+		if m.PreviewVisible {
+			m.updatePreviewContent()
+		}
+
+		// Then handle action keys
+		actionModel, actionCmd := m.handleKeyPress(msg.String())
+		if listCmd != nil {
+			return actionModel, tea.Batch(listCmd, actionCmd)
+		}
+		return actionModel, actionCmd
 
 	// ─── Data loaded messages ────────────────────────────────────────
 	case updateCheckMsg:
@@ -85,6 +143,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Screen = ScreenSearchResults
 		m.Cursor = 0
 		m.Scroll = 0
+		// Populate bubbles/list
+		items := make([]list.Item, len(msg.results))
+		for i, r := range msg.results {
+			items[i] = searchResultItem{result: r}
+		}
+		m.SearchListModel.SetItems(items)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 10
+		if h < 5 {
+			h = 5
+		}
+		m.SearchListModel.SetSize(w, h)
 		return m, nil
 
 	case recentObservationsMsg:
@@ -93,6 +166,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.RecentObservations = msg.observations
+		// Populate bubbles/list
+		items := make([]list.Item, len(msg.observations))
+		for i, o := range msg.observations {
+			items[i] = observationItem{obs: o}
+		}
+		m.RecentList.SetItems(items)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 8
+		if h < 5 {
+			h = 5
+		}
+		m.RecentList.SetSize(w, h)
 		return m, nil
 
 	case observationDetailMsg:
@@ -139,6 +227,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.Sessions = msg.sessions
+		// Populate bubbles/list
+		items := make([]list.Item, len(msg.sessions))
+		for i, s := range msg.sessions {
+			items[i] = sessionItem{session: s}
+		}
+		m.SessionListModel.SetItems(items)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 8
+		if h < 5 {
+			h = 5
+		}
+		m.SessionListModel.SetSize(w, h)
 		return m, nil
 
 	case sessionObservationsMsg:
@@ -162,6 +265,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Screen = ScreenGraph
 		m.Cursor = 0
 		m.Scroll = 0
+		// Populate bubbles/list
+		items := make([]list.Item, len(msg.related))
+		for i, o := range msg.related {
+			edgeLabel := ""
+			for _, e := range msg.edges {
+				if e.FromObsID == o.ID || e.ToObsID == o.ID {
+					edgeLabel = e.RelationType
+					break
+				}
+			}
+			items[i] = graphItem{obs: o, edgeLabel: edgeLabel}
+		}
+		m.GraphListModel.SetItems(items)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 12
+		if h < 5 {
+			h = 5
+		}
+		m.GraphListModel.SetSize(w, h)
 		return m, nil
 
 	case healthLoadedMsg:
@@ -182,6 +307,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.ArchivedObservations = msg.observations
+		// Populate bubbles/list
+		items := make([]list.Item, len(msg.observations))
+		for i, o := range msg.observations {
+			items[i] = observationItem{obs: o}
+		}
+		m.ArchiveList.SetItems(items)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 8
+		if h < 5 {
+			h = 5
+		}
+		m.ArchiveList.SetSize(w, h)
 		return m, nil
 
 	case setupInstallMsg:
@@ -623,15 +763,6 @@ func (m Model) handleSearchKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Search Results ─────────────────────────────────────────────────────────
 
 func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
-	visibleItems := (m.Height - 10) / linesPerItem
-	if visibleItems < minVisibleItems {
-		visibleItems = minVisibleItems
-	}
-
-	if key != "g" {
-		m.PendingKey = ""
-	}
-
 	// Confirm delete
 	if m.ConfirmDelete {
 		switch key {
@@ -645,50 +776,18 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 	}
 
 	switch key {
-	case "G":
-		if len(m.SearchResults) > 0 {
-			m.Cursor = len(m.SearchResults) - 1
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
-	case "g":
-		if m.PendingKey == "g" {
-			m.Cursor = 0
-			m.Scroll = 0
-			m.PendingKey = ""
-		} else {
-			m.PendingKey = "g"
-		}
-		return m, nil
-	case "up", "k":
-		if m.Cursor > 0 {
-			m.Cursor--
-			if m.Cursor < m.Scroll {
-				m.Scroll = m.Cursor
-			}
-		}
-	case "down", "j":
-		if m.Cursor < len(m.SearchResults)-1 {
-			m.Cursor++
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
 	case "enter":
-		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
-			obsID := m.SearchResults[m.Cursor].ID
+		if item, ok := m.SearchListModel.SelectedItem().(searchResultItem); ok {
 			m.PrevScreen = ScreenSearchResults
-			m.PrevCursor = m.Cursor
+			m.PrevCursor = m.SearchListModel.Index()
 			m.DetailLoading = true
-			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, item.result.ID))
 		}
 	case "t":
-		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
-			obsID := m.SearchResults[m.Cursor].ID
+		if item, ok := m.SearchListModel.SelectedItem().(searchResultItem); ok {
 			m.PrevScreen = ScreenSearchResults
-			m.PrevCursor = m.Cursor
-			return m, loadTimeline(m.deps, obsID)
+			m.PrevCursor = m.SearchListModel.Index()
+			return m, loadTimeline(m.deps, item.result.ID)
 		}
 	case "f":
 		if m.Stats != nil && len(m.Stats.Projects) > 0 {
@@ -704,11 +803,10 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			return m, searchMemories(m.deps, m.SearchQuery, m.FilterProject)
 		}
 	case "d":
-		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
-			obs := m.SearchResults[m.Cursor]
+		if item, ok := m.SearchListModel.SelectedItem().(searchResultItem); ok {
 			m.ConfirmDelete = true
-			m.ConfirmDeleteID = obs.ID
-			m.DeleteTargetTitle = obs.Title
+			m.ConfirmDeleteID = item.result.ID
+			m.DeleteTargetTitle = item.result.Title
 		}
 		return m, nil
 	case "/", "s":
@@ -716,7 +814,27 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 		m.Screen = ScreenSearch
 		m.SearchInput.Focus()
 		return m, nil
+	case "p":
+		if m.Width >= 100 {
+			m.PreviewVisible = !m.PreviewVisible
+			if m.PreviewVisible {
+				m.PreviewViewport = viewport.New(m.Width*3/5-6, m.Height-10)
+				m.updatePreviewContent()
+				// Shrink list to left pane
+				listWidth := m.Width * 2 / 5
+				m.SearchListModel.SetSize(listWidth-4, m.Height-10)
+			} else {
+				// Restore full-width list
+				w := m.Width - 4
+				if w < 20 {
+					w = 20
+				}
+				m.SearchListModel.SetSize(w, m.Height-10)
+			}
+		}
+		return m, nil
 	case "esc", "q":
+		m.PreviewVisible = false
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSearch
 		m.Cursor = 0
@@ -730,15 +848,6 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Recent Observations ────────────────────────────────────────────────────
 
 func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
-	visibleItems := (m.Height - 8) / linesPerItem
-	if visibleItems < minVisibleItems {
-		visibleItems = minVisibleItems
-	}
-
-	if key != "g" {
-		m.PendingKey = ""
-	}
-
 	// Confirm delete
 	if m.ConfirmDelete {
 		switch key {
@@ -752,57 +861,24 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 	}
 
 	switch key {
-	case "G":
-		if len(m.RecentObservations) > 0 {
-			m.Cursor = len(m.RecentObservations) - 1
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
-	case "g":
-		if m.PendingKey == "g" {
-			m.Cursor = 0
-			m.Scroll = 0
-			m.PendingKey = ""
-		} else {
-			m.PendingKey = "g"
-		}
-		return m, nil
-	case "up", "k":
-		if m.Cursor > 0 {
-			m.Cursor--
-			if m.Cursor < m.Scroll {
-				m.Scroll = m.Cursor
-			}
-		}
-	case "down", "j":
-		if m.Cursor < len(m.RecentObservations)-1 {
-			m.Cursor++
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
 	case "enter":
-		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
-			obsID := m.RecentObservations[m.Cursor].ID
+		if item, ok := m.RecentList.SelectedItem().(observationItem); ok {
 			m.PrevScreen = ScreenRecent
-			m.PrevCursor = m.Cursor
+			m.PrevCursor = m.RecentList.Index()
 			m.DetailLoading = true
-			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, item.obs.ID))
 		}
 	case "t":
-		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
-			obsID := m.RecentObservations[m.Cursor].ID
+		if item, ok := m.RecentList.SelectedItem().(observationItem); ok {
 			m.PrevScreen = ScreenRecent
-			m.PrevCursor = m.Cursor
-			return m, loadTimeline(m.deps, obsID)
+			m.PrevCursor = m.RecentList.Index()
+			return m, loadTimeline(m.deps, item.obs.ID)
 		}
 	case "d":
-		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
-			obs := m.RecentObservations[m.Cursor]
+		if item, ok := m.RecentList.SelectedItem().(observationItem); ok {
 			m.ConfirmDelete = true
-			m.ConfirmDeleteID = obs.ID
-			m.DeleteTargetTitle = obs.Title
+			m.ConfirmDeleteID = item.obs.ID
+			m.DeleteTargetTitle = item.obs.Title
 		}
 		return m, nil
 	case "f":
@@ -818,7 +894,27 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			m.FilterProject = projects[(currentIdx+1)%len(projects)]
 			return m, loadRecentObservations(m.deps, m.FilterProject)
 		}
+	case "p":
+		if m.Width >= 100 {
+			m.PreviewVisible = !m.PreviewVisible
+			if m.PreviewVisible {
+				m.PreviewViewport = viewport.New(m.Width*3/5-6, m.Height-10)
+				m.updatePreviewContent()
+				// Shrink list to left pane
+				listWidth := m.Width * 2 / 5
+				m.RecentList.SetSize(listWidth-4, m.Height-8)
+			} else {
+				// Restore full-width list
+				w := m.Width - 4
+				if w < 20 {
+					w = 20
+				}
+				m.RecentList.SetSize(w, m.Height-8)
+			}
+		}
+		return m, nil
 	case "esc", "q":
+		m.PreviewVisible = false
 		m.Screen = ScreenDashboard
 		m.Cursor = 0
 		m.Scroll = 0
@@ -911,52 +1007,12 @@ func (m Model) handleTimelineKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Sessions ───────────────────────────────────────────────────────────────
 
 func (m Model) handleSessionsKeys(key string) (tea.Model, tea.Cmd) {
-	visibleItems := m.Height - 8
-	if visibleItems < minVisibleItems+2 {
-		visibleItems = minVisibleItems + 2
-	}
-
-	if key != "g" {
-		m.PendingKey = ""
-	}
-
 	switch key {
-	case "G":
-		if len(m.Sessions) > 0 {
-			m.Cursor = len(m.Sessions) - 1
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
-	case "g":
-		if m.PendingKey == "g" {
-			m.Cursor = 0
-			m.Scroll = 0
-			m.PendingKey = ""
-		} else {
-			m.PendingKey = "g"
-		}
-		return m, nil
-	case "up", "k":
-		if m.Cursor > 0 {
-			m.Cursor--
-			if m.Cursor < m.Scroll {
-				m.Scroll = m.Cursor
-			}
-		}
-	case "down", "j":
-		if m.Cursor < len(m.Sessions)-1 {
-			m.Cursor++
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
 	case "enter":
-		if len(m.Sessions) > 0 && m.Cursor < len(m.Sessions) {
-			m.SelectedSessionIdx = m.Cursor
+		if item, ok := m.SessionListModel.SelectedItem().(sessionItem); ok {
+			m.SelectedSessionIdx = m.SessionListModel.Index()
 			m.PrevScreen = ScreenSessions
-			sessionID := m.Sessions[m.Cursor].Session.ID
-			return m, loadSessionObservations(m.deps, sessionID)
+			return m, loadSessionObservations(m.deps, item.session.Session.ID)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard
@@ -1015,61 +1071,20 @@ func (m Model) handleSessionDetailKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Graph (Cortex-exclusive) ───────────────────────────────────────────────
 
 func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
-	visibleItems := (m.Height - 8) / linesPerItem
-	if visibleItems < minVisibleItems {
-		visibleItems = minVisibleItems
-	}
-
-	if key != "g" {
-		m.PendingKey = ""
-	}
-
 	switch key {
-	case "G":
-		if len(m.GraphObservations) > 0 {
-			m.Cursor = len(m.GraphObservations) - 1
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
-	case "g":
-		if m.PendingKey == "g" {
-			m.Cursor = 0
-			m.Scroll = 0
-			m.PendingKey = ""
-		} else {
-			m.PendingKey = "g"
-		}
-		return m, nil
-	case "up", "k":
-		if m.Cursor > 0 {
-			m.Cursor--
-			if m.Cursor < m.Scroll {
-				m.Scroll = m.Cursor
-			}
-		}
-	case "down", "j":
-		if m.Cursor < len(m.GraphObservations)-1 {
-			m.Cursor++
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
 	case "enter":
-		if len(m.GraphObservations) > 0 && m.Cursor < len(m.GraphObservations) {
-			obsID := m.GraphObservations[m.Cursor].ID
+		if item, ok := m.GraphListModel.SelectedItem().(graphItem); ok {
 			m.PrevScreen = ScreenGraph
 			m.DetailLoading = true
-			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, item.obs.ID))
 		}
 	case "r":
 		// Re-root graph on selected observation
-		if len(m.GraphObservations) > 0 && m.Cursor < len(m.GraphObservations) {
-			obsID := m.GraphObservations[m.Cursor].ID
-			m.GraphRootID = obsID
+		if item, ok := m.GraphListModel.SelectedItem().(graphItem); ok {
+			m.GraphRootID = item.obs.ID
 			m.Cursor = 0
 			m.Scroll = 0
-			return m, loadGraphRelated(m.deps, obsID)
+			return m, loadGraphRelated(m.deps, item.obs.ID)
 		}
 	case "esc", "q":
 		m.Screen = m.PrevScreen
@@ -1083,15 +1098,6 @@ func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Archive (Cortex-exclusive) ─────────────────────────────────────────────
 
 func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
-	visibleItems := (m.Height - 8) / linesPerItem
-	if visibleItems < minVisibleItems {
-		visibleItems = minVisibleItems
-	}
-
-	if key != "g" {
-		m.PendingKey = ""
-	}
-
 	if m.ConfirmDelete {
 		switch key {
 		case "y", "Y":
@@ -1104,54 +1110,21 @@ func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
 	}
 
 	switch key {
-	case "G":
-		if len(m.ArchivedObservations) > 0 {
-			m.Cursor = len(m.ArchivedObservations) - 1
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
-	case "g":
-		if m.PendingKey == "g" {
-			m.Cursor = 0
-			m.Scroll = 0
-			m.PendingKey = ""
-		} else {
-			m.PendingKey = "g"
-		}
-		return m, nil
-	case "up", "k":
-		if m.Cursor > 0 {
-			m.Cursor--
-			if m.Cursor < m.Scroll {
-				m.Scroll = m.Cursor
-			}
-		}
-	case "down", "j":
-		if m.Cursor < len(m.ArchivedObservations)-1 {
-			m.Cursor++
-			if m.Cursor >= m.Scroll+visibleItems {
-				m.Scroll = m.Cursor - visibleItems + 1
-			}
-		}
 	case "enter":
-		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
-			obsID := m.ArchivedObservations[m.Cursor].ID
+		if item, ok := m.ArchiveList.SelectedItem().(observationItem); ok {
 			m.PrevScreen = ScreenArchive
 			m.DetailLoading = true
-			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, item.obs.ID))
 		}
 	case "u":
-		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
-			obsID := m.ArchivedObservations[m.Cursor].ID
-			return m, unarchiveObservationCmd(m.deps, obsID)
+		if item, ok := m.ArchiveList.SelectedItem().(observationItem); ok {
+			return m, unarchiveObservationCmd(m.deps, item.obs.ID)
 		}
 	case "d":
-		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
-			obs := m.ArchivedObservations[m.Cursor]
+		if item, ok := m.ArchiveList.SelectedItem().(observationItem); ok {
 			m.ConfirmDelete = true
-			m.ConfirmDeleteID = obs.ID
-			m.DeleteTargetTitle = obs.Title
+			m.ConfirmDeleteID = item.obs.ID
+			m.DeleteTargetTitle = item.obs.Title
 		}
 		return m, nil
 	case "f":
@@ -1572,6 +1545,28 @@ func buildDetailContent(obs *domain.Observation, score *domain.ImportanceScore, 
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+// updatePreviewContent sets the preview viewport content based on the
+// currently selected item in the active list screen.
+func (m *Model) updatePreviewContent() {
+	var content string
+	switch m.Screen {
+	case ScreenSearchResults:
+		if item, ok := m.SearchListModel.SelectedItem().(searchResultItem); ok {
+			r := item.result
+			content = fmt.Sprintf("Title: %s\nType: %s\nProject: %s\nCreated: %s\nScore: %.0f%%\n\n%s",
+				r.Title, r.Type, r.Project, formatTime(r.CreatedAt), r.Rank*100, r.Content)
+		}
+	case ScreenRecent:
+		if item, ok := m.RecentList.SelectedItem().(observationItem); ok {
+			o := item.obs
+			content = fmt.Sprintf("Title: %s\nType: %s\nProject: %s\nCreated: %s\n\n%s",
+				o.Title, o.Type, o.Project, formatTime(o.CreatedAt), o.Content)
+		}
+	}
+	m.PreviewViewport.SetContent(content)
+	m.PreviewViewport.GotoTop()
+}
 
 func (m Model) refreshScreen(screen Screen) tea.Cmd {
 	switch screen {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2,10 +2,13 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/lleontor705/cortex/internal/setup"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -23,11 +26,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		if m.Screen == ScreenObservationDetail {
+			w := m.Width - 4
+			if w < 20 {
+				w = 20
+			}
+			h := m.Height - 8
+			if h < 5 {
+				h = 5
+			}
+			m.DetailViewport.Width = w
+			m.DetailViewport.Height = h
+		}
 		return m, nil
 
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
+		}
+		// Command palette intercept
+		if m.CmdPaletteOpen {
+			return m.handleCmdPaletteKeys(msg)
 		}
 		if m.Screen == ScreenSearch && m.SearchInput.Focused() {
 			return m.handleSearchInputKeys(msg)
@@ -48,6 +67,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.Stats = msg.stats
+		return m, nil
+
+	case activityDataMsg:
+		if msg.err == nil {
+			m.ActivityData = msg.daily
+		}
 		return m, nil
 
 	case searchResultsMsg:
@@ -81,7 +106,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.DetailEntities = msg.entities
 		m.DetailEdges = msg.edges
 		m.Screen = ScreenObservationDetail
-		m.DetailScroll = 0
+
+		// Build viewport content
+		contentStr := buildDetailContent(msg.observation, msg.score, msg.entities, msg.edges)
+		w := m.Width - 4
+		if w < 20 {
+			w = 20
+		}
+		h := m.Height - 8
+		if h < 5 {
+			h = 5
+		}
+		m.DetailViewport = viewport.New(w, h)
+		m.DetailViewport.SetContent(contentStr)
 		return m, nil
 
 	case timelineMsg:
@@ -190,6 +227,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case reindexProgressMsg:
 		m.EmbCfgReindexing = false
+		m.ReindexTotal = msg.total
+		m.ReindexDone = msg.indexed
 		if msg.err != nil {
 			m.EmbCfgError = msg.err.Error()
 			return m, nil
@@ -296,6 +335,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		return m, nil
+
+	case tea.MouseMsg:
+		if msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown {
+			// Scroll delegated to active component
+			switch m.Screen {
+			case ScreenObservationDetail:
+				var cmd tea.Cmd
+				m.DetailViewport, cmd = m.DetailViewport.Update(msg)
+				return m, cmd
+			}
+		}
+		return m, nil
 	}
 
 	return m, nil
@@ -323,6 +374,15 @@ func (m Model) handleKeyPress(key string) (tea.Model, tea.Cmd) {
 	if key == "?" && m.Screen != ScreenSearch && m.Screen != ScreenEmbeddingConfig && m.Screen != ScreenHelp {
 		m.PrevScreen = m.Screen
 		m.Screen = ScreenHelp
+		return m, nil
+	}
+
+	// Command palette
+	if key == "ctrl+k" {
+		m.CmdPaletteOpen = true
+		m.CmdPaletteCursor = 0
+		m.CmdPaletteInput.SetValue("")
+		m.CmdPaletteInput.Focus()
 		return m, nil
 	}
 
@@ -783,16 +843,13 @@ func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
 
 	switch key {
 	case "up", "k":
-		if m.DetailScroll > 0 {
-			m.DetailScroll--
-		}
+		m.DetailViewport.ScrollUp(1)
 	case "down", "j":
-		// Bounded scroll — view.go clamps to maxScroll during rendering,
-		// but we cap here to avoid ever-growing scroll values.
-		m.DetailScroll++
-		if m.DetailScroll > maxScrollOffset {
-			m.DetailScroll = maxScrollOffset
-		}
+		m.DetailViewport.ScrollDown(1)
+	case "pgup":
+		m.DetailViewport.HalfPageUp()
+	case "pgdown":
+		m.DetailViewport.HalfPageDown()
 	case "t":
 		if m.SelectedObservation != nil {
 			m.PrevScreen = ScreenObservationDetail
@@ -823,7 +880,7 @@ func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
 	case "esc", "q":
 		m.Screen = m.PrevScreen
 		m.Cursor = m.PrevCursor
-		m.DetailScroll = 0
+		m.DetailViewport.GotoTop()
 		return m, m.refreshScreen(m.PrevScreen)
 	}
 	return m, nil
@@ -1364,6 +1421,154 @@ func (m Model) handleHelpKeys(key string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+// ─── Command Palette ──────────────────────────────────────────────────────
+
+type paletteCommand struct {
+	name     string
+	shortcut string
+	execute  func(m Model) (Model, tea.Cmd)
+}
+
+func allCommands() []paletteCommand {
+	return []paletteCommand{
+		{"Search memories", "/", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenSearch
+			m.SearchInput.Focus()
+			return m, nil
+		}},
+		{"Recent observations", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenRecent
+			return m, loadRecentObservations(m.deps, m.FilterProject)
+		}},
+		{"Browse sessions", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenSessions
+			return m, loadRecentSessions(m.deps)
+		}},
+		{"Knowledge graph", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenGraph
+			return m, nil
+		}},
+		{"Memory health", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenHealth
+			return m, loadHealthData(m.deps, "")
+		}},
+		{"Archived observations", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenArchive
+			return m, loadArchivedObservations(m.deps, m.FilterProject)
+		}},
+		{"Embedding settings", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenEmbeddingConfig
+			return m, nil
+		}},
+		{"Setup agent plugin", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenSetup
+			return m, nil
+		}},
+		{"Help / Keyboard shortcuts", "?", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenHelp
+			return m, nil
+		}},
+		{"Go to Dashboard", "", func(m Model) (Model, tea.Cmd) {
+			m.Screen = ScreenDashboard
+			return m, loadStats(m.deps)
+		}},
+	}
+}
+
+func (m Model) filteredCommands() []paletteCommand {
+	query := strings.ToLower(m.CmdPaletteInput.Value())
+	if query == "" {
+		return allCommands()
+	}
+	var filtered []paletteCommand
+	for _, cmd := range allCommands() {
+		if strings.Contains(strings.ToLower(cmd.name), query) {
+			filtered = append(filtered, cmd)
+		}
+	}
+	return filtered
+}
+
+func (m Model) handleCmdPaletteKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "esc":
+		m.CmdPaletteOpen = false
+		m.CmdPaletteInput.Blur()
+		return m, nil
+	case "up", "ctrl+p":
+		if m.CmdPaletteCursor > 0 {
+			m.CmdPaletteCursor--
+		}
+		return m, nil
+	case "down", "ctrl+n":
+		filtered := m.filteredCommands()
+		if m.CmdPaletteCursor < len(filtered)-1 {
+			m.CmdPaletteCursor++
+		}
+		return m, nil
+	case "enter":
+		filtered := m.filteredCommands()
+		if len(filtered) > 0 && m.CmdPaletteCursor < len(filtered) {
+			cmd := filtered[m.CmdPaletteCursor]
+			m.CmdPaletteOpen = false
+			m.CmdPaletteInput.Blur()
+			return cmd.execute(m)
+		}
+		return m, nil
+	}
+	// Pass to text input for filtering
+	var cmd tea.Cmd
+	m.CmdPaletteInput, cmd = m.CmdPaletteInput.Update(msg)
+	m.CmdPaletteCursor = 0 // reset cursor on filter change
+	return m, cmd
+}
+
+
+// ─── Detail Content Builder ────────────────────────────────────────────────
+
+// buildDetailContent constructs the full text content for the observation
+// detail viewport. This is called once when the observation loads, and
+// the viewport handles scrolling from there.
+func buildDetailContent(obs *domain.Observation, score *domain.ImportanceScore, entities []*domain.EntityLink, edges []*domain.Edge) string {
+	var content strings.Builder
+
+	fmt.Fprintf(&content, "Type:       %s\n", obs.Type)
+	fmt.Fprintf(&content, "Title:      %s\n", obs.Title)
+	fmt.Fprintf(&content, "Session:    %s\n", obs.SessionID)
+	fmt.Fprintf(&content, "Created:    %s\n", obs.CreatedAt.Format("2006-01-02 15:04"))
+	if obs.Project != "" {
+		fmt.Fprintf(&content, "Project:    %s\n", obs.Project)
+	}
+
+	if score != nil {
+		fmt.Fprintf(&content, "Score:      %.1f/5.0  (accessed %d times)\n", score.Score, score.AccessCount)
+	}
+
+	if len(entities) > 0 {
+		content.WriteString("\n── Entities ──\n")
+		for _, e := range entities {
+			fmt.Fprintf(&content, "  [%s] %s\n", e.EntityType, e.EntityValue)
+		}
+	}
+
+	if len(edges) > 0 {
+		fmt.Fprintf(&content, "\n── Related (%d links) ──\n", len(edges))
+		for _, e := range edges {
+			targetID := e.ToObsID
+			if targetID == obs.ID {
+				targetID = e.FromObsID
+			}
+			fmt.Fprintf(&content, "  [%s] #%d  weight: %.1f\n", e.RelationType, targetID, e.Weight)
+		}
+	}
+
+	content.WriteString("\n── Content ──\n")
+	content.WriteString(obs.Content)
+
+	return content.String()
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+
 	"github.com/lleontor705/cortex/internal/setup"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -69,6 +71,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case observationDetailMsg:
+		m.DetailLoading = false
 		if msg.err != nil {
 			m.ErrorMsg = msg.err.Error()
 			return m, nil
@@ -169,12 +172,53 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.EmbCfgSaved = true
 		m.EmbCfgError = ""
+		m.EmbCfgDirty = false
+		// Detect provider/model changes for reindex warning
+		providerChanged := m.EmbCfgProvider != m.EmbCfgOriginalProvider
+		modelChanged := m.EmbCfgModel.Value() != m.EmbCfgOriginalModel
+		if providerChanged || modelChanged {
+			m.EmbCfgReindexWarning = true
+		}
+		m.EmbCfgOriginalProvider = m.EmbCfgProvider
+		m.EmbCfgOriginalModel = m.EmbCfgModel.Value()
 		// If ollama is configured, check its status
 		if m.EmbCfgProvider == 1 {
 			m.EmbCfgOllamaChecked = false
 			return m, checkOllamaStatus(m.deps)
 		}
 		return m, nil
+
+	case reindexProgressMsg:
+		m.EmbCfgReindexing = false
+		if msg.err != nil {
+			m.EmbCfgError = msg.err.Error()
+			return m, nil
+		}
+		if msg.done {
+			m.EmbCfgReindexProgress = msg.progress
+			m.EmbCfgReindexWarning = false
+		}
+		return m, nil
+
+	case deleteObservationMsg:
+		if msg.err != nil {
+			m.ErrorMsg = msg.err.Error()
+			return m, nil
+		}
+		m.ConfirmDelete = false
+		m.ConfirmDeleteID = 0
+		m.ToastMessage = fmt.Sprintf("Observation #%d deleted", msg.id)
+		m.ToastType = "success"
+		return m, m.refreshScreen(m.Screen)
+
+	case unarchiveObservationMsg:
+		if msg.err != nil {
+			m.ErrorMsg = msg.err.Error()
+			return m, nil
+		}
+		m.ToastMessage = fmt.Sprintf("Observation #%d restored", msg.id)
+		m.ToastType = "success"
+		return m, loadArchivedObservations(m.deps, m.FilterProject)
 
 	case ollamaStatusMsg:
 		m.EmbCfgOllamaChecked = true
@@ -206,6 +250,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case configReloadedMsg:
 		m.EmbCfgSaving = false
+		m.EmbCfgDirty = false
 		if msg.err != nil {
 			m.EmbCfgError = msg.err.Error()
 			return m, nil
@@ -235,12 +280,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
+		if m.DetailLoading {
+			var cmd tea.Cmd
+			m.SetupSpinner, cmd = m.SetupSpinner.Update(msg)
+			return m, cmd
+		}
 		if m.SetupInstalling {
 			var cmd tea.Cmd
 			m.SetupSpinner, cmd = m.SetupSpinner.Update(msg)
 			return m, cmd
 		}
-		if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving {
+		if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving || m.EmbCfgReindexing {
 			var cmd tea.Cmd
 			m.EmbCfgSpinner, cmd = m.EmbCfgSpinner.Update(msg)
 			return m, cmd
@@ -256,7 +306,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) handleKeyPress(key string) (tea.Model, tea.Cmd) {
 	m.ErrorMsg = ""
 
+	// Clear toast on any key press
+	if m.ToastMessage != "" {
+		m.ToastMessage = ""
+		m.ToastType = ""
+	}
+
+	// Cancel delete confirmation on any key except y/Y
+	if m.ConfirmDelete && key != "y" && key != "Y" {
+		m.ConfirmDelete = false
+		m.ConfirmDeleteID = 0
+		return m, nil
+	}
+
+	// Global help key — skip for screens with text input
+	if key == "?" && m.Screen != ScreenSearch && m.Screen != ScreenEmbeddingConfig && m.Screen != ScreenHelp {
+		m.PrevScreen = m.Screen
+		m.Screen = ScreenHelp
+		return m, nil
+	}
+
 	switch m.Screen {
+	case ScreenHelp:
+		return m.handleHelpKeys(key)
 	case ScreenDashboard:
 		return m.handleDashboardKeys(key)
 	case ScreenSearch:
@@ -340,7 +412,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.Screen = ScreenRecent
 		m.Cursor = 0
 		m.Scroll = 0
-		return m, loadRecentObservations(m.deps)
+		return m, loadRecentObservations(m.deps, m.FilterProject)
 	case 2: // Sessions
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSessions
@@ -357,7 +429,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 			m.GraphRootID = m.RecentObservations[0].ID
 			return m, loadGraphRelated(m.deps, m.GraphRootID)
 		}
-		return m, loadRecentObservations(m.deps)
+		return m, loadRecentObservations(m.deps, m.FilterProject)
 	case 4: // Memory health
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenHealth
@@ -373,7 +445,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.Screen = ScreenArchive
 		m.Cursor = 0
 		m.Scroll = 0
-		return m, loadArchivedObservations(m.deps)
+		return m, loadArchivedObservations(m.deps, m.FilterProject)
 	case 6: // Embedding settings
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenEmbeddingConfig
@@ -382,9 +454,13 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.EmbCfgSaved = false
 		m.EmbCfgSaving = false
 		m.EmbCfgError = ""
+		m.EmbCfgDirty = false
 		m.EmbCfgOllamaChecked = false
 		m.EmbCfgPulling = false
 		m.EmbCfgStarting = false
+		m.EmbCfgReindexWarning = false
+		m.EmbCfgReindexing = false
+		m.EmbCfgReindexProgress = ""
 		// Reload current config values
 		if m.deps.Config != nil {
 			switch m.deps.Config.Search.EmbeddingProvider {
@@ -399,6 +475,9 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 			m.EmbCfgVector = m.deps.Config.Search.Vector
 			m.EmbCfgAutoStart = m.deps.Config.Search.OllamaAutoStart
 		}
+		// Save original values for change detection
+		m.EmbCfgOriginalProvider = m.EmbCfgProvider
+		m.EmbCfgOriginalModel = m.EmbCfgModel.Value()
 		return m, nil
 	case 7: // Setup
 		m.PrevScreen = ScreenDashboard
@@ -427,10 +506,35 @@ func (m Model) handleSearchInputKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		query := m.SearchInput.Value()
 		if query != "" {
+			// Append to search history (max 20 entries)
+			m.SearchHistory = append(m.SearchHistory, query)
+			if len(m.SearchHistory) > 20 {
+				m.SearchHistory = m.SearchHistory[len(m.SearchHistory)-20:]
+			}
+			m.SearchHistoryIdx = len(m.SearchHistory)
 			m.SearchInput.Blur()
-			return m, searchMemories(m.deps, query)
+			return m, searchMemories(m.deps, query, m.FilterProject)
 		}
 		return m, nil
+	case "up":
+		if len(m.SearchHistory) > 0 {
+			if m.SearchHistoryIdx > 0 {
+				m.SearchHistoryIdx--
+			}
+			m.SearchInput.SetValue(m.SearchHistory[m.SearchHistoryIdx])
+			return m, nil
+		}
+	case "down":
+		if len(m.SearchHistory) > 0 {
+			if m.SearchHistoryIdx < len(m.SearchHistory)-1 {
+				m.SearchHistoryIdx++
+				m.SearchInput.SetValue(m.SearchHistory[m.SearchHistoryIdx])
+			} else {
+				m.SearchHistoryIdx = len(m.SearchHistory)
+				m.SearchInput.SetValue("")
+			}
+			return m, nil
+		}
 	case "esc":
 		m.SearchInput.Blur()
 		m.Screen = ScreenDashboard
@@ -464,7 +568,39 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	// Confirm delete
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservationCmd(m.deps, m.ConfirmDeleteID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.SearchResults) > 0 {
+			m.Cursor = len(m.SearchResults) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -484,7 +620,8 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			obsID := m.SearchResults[m.Cursor].ID
 			m.PrevScreen = ScreenSearchResults
 			m.PrevCursor = m.Cursor
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
@@ -493,6 +630,27 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevCursor = m.Cursor
 			return m, loadTimeline(m.deps, obsID)
 		}
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, searchMemories(m.deps, m.SearchQuery, m.FilterProject)
+		}
+	case "d":
+		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
+			obs := m.SearchResults[m.Cursor]
+			m.ConfirmDelete = true
+			m.ConfirmDeleteID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
 	case "/", "s":
 		m.PrevScreen = ScreenSearchResults
 		m.Screen = ScreenSearch
@@ -517,7 +675,39 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	// Confirm delete
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservationCmd(m.deps, m.ConfirmDeleteID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.RecentObservations) > 0 {
+			m.Cursor = len(m.RecentObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -537,7 +727,8 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			obsID := m.RecentObservations[m.Cursor].ID
 			m.PrevScreen = ScreenRecent
 			m.PrevCursor = m.Cursor
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
@@ -545,6 +736,27 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenRecent
 			m.PrevCursor = m.Cursor
 			return m, loadTimeline(m.deps, obsID)
+		}
+	case "d":
+		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
+			obs := m.RecentObservations[m.Cursor]
+			m.ConfirmDelete = true
+			m.ConfirmDeleteID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, loadRecentObservations(m.deps, m.FilterProject)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard
@@ -558,6 +770,17 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Observation Detail ─────────────────────────────────────────────────────
 
 func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservationCmd(m.deps, m.ConfirmDeleteID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
 	case "up", "k":
 		if m.DetailScroll > 0 {
@@ -582,6 +805,21 @@ func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenObservationDetail
 			return m, loadGraphRelated(m.deps, m.SelectedObservation.ID)
 		}
+	case "s", "S":
+		if m.SelectedObservation != nil && m.SelectedObservation.SessionID != "" {
+			m.PrevScreen = ScreenObservationDetail
+			m.Screen = ScreenSessionDetail
+			m.Cursor = 0
+			m.SessionDetailScroll = 0
+			return m, loadSessionObservations(m.deps, m.SelectedObservation.SessionID)
+		}
+	case "d":
+		if m.SelectedObservation != nil {
+			m.ConfirmDelete = true
+			m.ConfirmDeleteID = m.SelectedObservation.ID
+			m.DeleteTargetTitle = m.SelectedObservation.Title
+		}
+		return m, nil
 	case "esc", "q":
 		m.Screen = m.PrevScreen
 		m.Cursor = m.PrevCursor
@@ -621,7 +859,27 @@ func (m Model) handleSessionsKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems + 2
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
 	switch key {
+	case "G":
+		if len(m.Sessions) > 0 {
+			m.Cursor = len(m.Sessions) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -679,7 +937,8 @@ func (m Model) handleSessionDetailKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {
 			obsID := m.SessionObservations[m.Cursor].ID
 			m.PrevScreen = ScreenSessionDetail
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "t":
 		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {
@@ -704,7 +963,27 @@ func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
 	switch key {
+	case "G":
+		if len(m.GraphObservations) > 0 {
+			m.Cursor = len(m.GraphObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -723,7 +1002,8 @@ func (m Model) handleGraphKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.GraphObservations) > 0 && m.Cursor < len(m.GraphObservations) {
 			obsID := m.GraphObservations[m.Cursor].ID
 			m.PrevScreen = ScreenGraph
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
 		}
 	case "r":
 		// Re-root graph on selected observation
@@ -751,7 +1031,38 @@ func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
 		visibleItems = minVisibleItems
 	}
 
+	if key != "g" {
+		m.PendingKey = ""
+	}
+
+	if m.ConfirmDelete {
+		switch key {
+		case "y", "Y":
+			m.ConfirmDelete = false
+			return m, deleteObservationCmd(m.deps, m.ConfirmDeleteID)
+		case "n", "N", "esc":
+			m.ConfirmDelete = false
+		}
+		return m, nil
+	}
+
 	switch key {
+	case "G":
+		if len(m.ArchivedObservations) > 0 {
+			m.Cursor = len(m.ArchivedObservations) - 1
+			if m.Cursor >= m.Scroll+visibleItems {
+				m.Scroll = m.Cursor - visibleItems + 1
+			}
+		}
+	case "g":
+		if m.PendingKey == "g" {
+			m.Cursor = 0
+			m.Scroll = 0
+			m.PendingKey = ""
+		} else {
+			m.PendingKey = "g"
+		}
+		return m, nil
 	case "up", "k":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -770,7 +1081,34 @@ func (m Model) handleArchiveKeys(key string) (tea.Model, tea.Cmd) {
 		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
 			obsID := m.ArchivedObservations[m.Cursor].ID
 			m.PrevScreen = ScreenArchive
-			return m, loadObservationDetail(m.deps, obsID)
+			m.DetailLoading = true
+			return m, tea.Batch(m.SetupSpinner.Tick, loadObservationDetail(m.deps, obsID))
+		}
+	case "u":
+		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
+			obsID := m.ArchivedObservations[m.Cursor].ID
+			return m, unarchiveObservationCmd(m.deps, obsID)
+		}
+	case "d":
+		if len(m.ArchivedObservations) > 0 && m.Cursor < len(m.ArchivedObservations) {
+			obs := m.ArchivedObservations[m.Cursor]
+			m.ConfirmDelete = true
+			m.ConfirmDeleteID = obs.ID
+			m.DeleteTargetTitle = obs.Title
+		}
+		return m, nil
+	case "f":
+		if m.Stats != nil && len(m.Stats.Projects) > 0 {
+			projects := append([]string{""}, m.Stats.Projects...)
+			currentIdx := 0
+			for i, p := range projects {
+				if p == m.FilterProject {
+					currentIdx = i
+					break
+				}
+			}
+			m.FilterProject = projects[(currentIdx+1)%len(projects)]
+			return m, loadArchivedObservations(m.deps, m.FilterProject)
 		}
 	case "esc", "q":
 		m.Screen = ScreenDashboard
@@ -794,6 +1132,13 @@ func (m Model) handleHealthKeys(key string) (tea.Model, tea.Cmd) {
 		if m.Scroll > maxScrollOffset {
 			m.Scroll = maxScrollOffset
 		}
+	case "tab":
+		m.HealthSection = (m.HealthSection + 1) % 3
+		m.HealthExpanded = false
+		m.Scroll = 0
+	case "enter":
+		m.HealthExpanded = !m.HealthExpanded
+		m.Scroll = 0
 	case "esc", "q":
 		m.Screen = ScreenDashboard
 		m.Cursor = 0
@@ -894,8 +1239,18 @@ func (m Model) handleEmbeddingModelInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleEmbeddingConfigKeys(key string) (tea.Model, tea.Cmd) {
 	// If async operation running, only allow esc
-	if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving {
+	if m.EmbCfgPulling || m.EmbCfgStarting || m.EmbCfgSaving || m.EmbCfgReindexing {
 		return m, nil
+	}
+
+	// Post-save: reindex key available when warning is shown
+	if m.EmbCfgSaved && m.EmbCfgReindexWarning && !m.EmbCfgReindexing {
+		if key == "x" || key == "X" {
+			m.EmbCfgReindexing = true
+			m.EmbCfgReindexWarning = false
+			m.EmbCfgError = ""
+			return m, tea.Batch(m.EmbCfgSpinner.Tick, startReindexCmd(m.deps))
+		}
 	}
 
 	// Post-save Ollama actions
@@ -962,17 +1317,21 @@ func (m Model) handleEmbeddingConfigKeys(key string) (tea.Model, tea.Cmd) {
 	case "left", "h":
 		if m.EmbCfgFocusField == 0 {
 			m.EmbCfgProvider = (m.EmbCfgProvider + 2) % 3 // cycle left
+			m.EmbCfgDirty = true
 		}
 	case "right", "l":
 		if m.EmbCfgFocusField == 0 {
 			m.EmbCfgProvider = (m.EmbCfgProvider + 1) % 3 // cycle right
+			m.EmbCfgDirty = true
 		}
 	case " ":
 		switch m.EmbCfgFocusField {
 		case 2:
 			m.EmbCfgVector = !m.EmbCfgVector
+			m.EmbCfgDirty = true
 		case 3:
 			m.EmbCfgAutoStart = !m.EmbCfgAutoStart
+			m.EmbCfgDirty = true
 		}
 	case "enter":
 		switch m.EmbCfgFocusField {
@@ -996,6 +1355,17 @@ func (m Model) handleEmbeddingConfigKeys(key string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// ─── Help ──────────────────────────────────────────────────────────────────
+
+func (m Model) handleHelpKeys(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "esc", "q", "?":
+		m.Screen = m.PrevScreen
+		return m, nil
+	}
+	return m, nil
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 func (m Model) refreshScreen(screen Screen) tea.Cmd {
@@ -1003,11 +1373,16 @@ func (m Model) refreshScreen(screen Screen) tea.Cmd {
 	case ScreenDashboard:
 		return loadStats(m.deps)
 	case ScreenRecent:
-		return loadRecentObservations(m.deps)
+		return loadRecentObservations(m.deps, m.FilterProject)
+	case ScreenSearchResults:
+		if m.SearchQuery != "" {
+			return searchMemories(m.deps, m.SearchQuery, m.FilterProject)
+		}
+		return nil
 	case ScreenSessions:
 		return loadRecentSessions(m.deps)
 	case ScreenArchive:
-		return loadArchivedObservations(m.deps)
+		return loadArchivedObservations(m.deps, m.FilterProject)
 	default:
 		return nil
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/lleontor705/cortex/internal/store/session"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -65,17 +66,24 @@ func TestHandleSearchResultsKeysScrollAndDetail(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenSearchResults
 	m.Width, m.Height = 120, 40
-	m.SearchResults = []*domain.SearchResult{
+	results := []*domain.SearchResult{
 		{Observation: domain.Observation{ID: 1, Title: "First"}},
 		{Observation: domain.Observation{ID: 2, Title: "Second"}},
 		{Observation: domain.Observation{ID: 3, Title: "Third"}},
 	}
+	m.SearchResults = results
+	items := make([]list.Item, len(results))
+	for i, r := range results {
+		items[i] = searchResultItem{result: r}
+	}
+	m.SearchListModel.SetItems(items)
+	m.SearchListModel.SetSize(116, 30)
 
-	// Move down
-	updated, _ := m.handleSearchResultsKeys("j")
+	// Move down via Update (list handles navigation)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.SearchListModel.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.SearchListModel.Index())
 	}
 
 	// Press enter to load detail
@@ -91,22 +99,30 @@ func TestHandleRecentKeysNavigation(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenRecent
 	m.Width, m.Height = 120, 40
-	m.RecentObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Title: "First"},
 		{ID: 2, Title: "Second"},
 	}
+	m.RecentObservations = obs
+	items := make([]list.Item, len(obs))
+	for i, o := range obs {
+		items[i] = observationItem{obs: o}
+	}
+	m.RecentList.SetItems(items)
+	m.RecentList.SetSize(116, 32)
 
-	updated, _ := m.handleRecentKeys("j")
+	// Move down via Update
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.RecentList.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.RecentList.Index())
 	}
 
 	// Can't go past end
-	updated, _ = result.handleRecentKeys("j")
+	updated, _ = result.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result = updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.RecentList.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.RecentList.Index())
 	}
 }
 
@@ -164,15 +180,23 @@ func TestHandleSessionsKeysNavigation(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenSessions
 	m.Width, m.Height = 120, 40
-	m.Sessions = []*session.SessionStats{
+	sessions := []*session.SessionStats{
 		{Session: &domain.Session{ID: "s1", Project: "p1"}, ObservationCount: 5},
 		{Session: &domain.Session{ID: "s2", Project: "p2"}, ObservationCount: 3},
 	}
+	m.Sessions = sessions
+	items := make([]list.Item, len(sessions))
+	for i, s := range sessions {
+		items[i] = sessionItem{session: s}
+	}
+	m.SessionListModel.SetItems(items)
+	m.SessionListModel.SetSize(116, 32)
 
-	updated, _ := m.handleSessionsKeys("j")
+	// Move down via Update
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.SessionListModel.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.SessionListModel.Index())
 	}
 
 	// Enter loads session observations
@@ -188,15 +212,23 @@ func TestHandleGraphKeysNavigation(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenGraph
 	m.Width, m.Height = 120, 40
-	m.GraphObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Title: "First"},
 		{ID: 2, Title: "Second"},
 	}
+	m.GraphObservations = obs
+	items := make([]list.Item, len(obs))
+	for i, o := range obs {
+		items[i] = graphItem{obs: o}
+	}
+	m.GraphListModel.SetItems(items)
+	m.GraphListModel.SetSize(116, 28)
 
-	updated, _ := m.handleGraphKeys("j")
+	// Move down via Update
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.GraphListModel.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.GraphListModel.Index())
 	}
 }
 
@@ -204,9 +236,13 @@ func TestHandleGraphKeysReroot(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenGraph
 	m.Width, m.Height = 120, 40
-	m.GraphObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 5, Title: "Related"},
 	}
+	m.GraphObservations = obs
+	items := []list.Item{graphItem{obs: obs[0]}}
+	m.GraphListModel.SetItems(items)
+	m.GraphListModel.SetSize(116, 28)
 
 	updated, cmd := m.handleGraphKeys("r")
 	if cmd == nil {
@@ -224,15 +260,23 @@ func TestHandleArchiveKeysNavigation(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenArchive
 	m.Width, m.Height = 120, 40
-	m.ArchivedObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Title: "Archived 1"},
 		{ID: 2, Title: "Archived 2"},
 	}
+	m.ArchivedObservations = obs
+	items := make([]list.Item, len(obs))
+	for i, o := range obs {
+		items[i] = observationItem{obs: o}
+	}
+	m.ArchiveList.SetItems(items)
+	m.ArchiveList.SetSize(116, 32)
 
-	updated, _ := m.handleArchiveKeys("j")
+	// Move down via Update
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 1 {
-		t.Fatalf("cursor = %d, want 1", result.Cursor)
+	if result.ArchiveList.Index() != 1 {
+		t.Fatalf("list index = %d, want 1", result.ArchiveList.Index())
 	}
 }
 
@@ -271,11 +315,11 @@ func TestHandleRecentKeysEmptyList(t *testing.T) {
 	m.Width, m.Height = 120, 40
 	m.RecentObservations = nil
 
-	// j/k should not panic
-	updated, _ := m.handleRecentKeys("j")
+	// j should not panic on empty list
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 0 {
-		t.Fatalf("cursor = %d, want 0", result.Cursor)
+	if result.RecentList.Index() != 0 {
+		t.Fatalf("list index = %d, want 0", result.RecentList.Index())
 	}
 
 	// enter should not panic
@@ -291,10 +335,11 @@ func TestHandleSearchResultsKeysEmptyList(t *testing.T) {
 	m.Width, m.Height = 120, 40
 	m.SearchResults = nil
 
-	updated, _ := m.handleSearchResultsKeys("j")
+	// j should not panic on empty list
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 0 {
-		t.Fatalf("cursor = %d", result.Cursor)
+	if result.SearchListModel.Index() != 0 {
+		t.Fatalf("list index = %d", result.SearchListModel.Index())
 	}
 
 	_, cmd := result.handleSearchResultsKeys("enter")
@@ -309,10 +354,11 @@ func TestHandleGraphKeysEmptyList(t *testing.T) {
 	m.Width, m.Height = 120, 40
 	m.GraphObservations = nil
 
-	updated, _ := m.handleGraphKeys("j")
+	// j should not panic on empty list
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 0 {
-		t.Fatalf("cursor = %d", result.Cursor)
+	if result.GraphListModel.Index() != 0 {
+		t.Fatalf("list index = %d", result.GraphListModel.Index())
 	}
 
 	_, cmd := result.handleGraphKeys("r")
@@ -327,10 +373,11 @@ func TestHandleArchiveKeysEmptyList(t *testing.T) {
 	m.Width, m.Height = 120, 40
 	m.ArchivedObservations = nil
 
-	updated, _ := m.handleArchiveKeys("j")
+	// j should not panic on empty list
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 0 {
-		t.Fatalf("cursor = %d", result.Cursor)
+	if result.ArchiveList.Index() != 0 {
+		t.Fatalf("list index = %d", result.ArchiveList.Index())
 	}
 
 	_, cmd := result.handleArchiveKeys("enter")
@@ -345,10 +392,11 @@ func TestHandleSessionsKeysEmptyList(t *testing.T) {
 	m.Width, m.Height = 120, 40
 	m.Sessions = nil
 
-	updated, _ := m.handleSessionsKeys("j")
+	// j should not panic on empty list
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	result := updated.(Model)
-	if result.Cursor != 0 {
-		t.Fatalf("cursor = %d", result.Cursor)
+	if result.SessionListModel.Index() != 0 {
+		t.Fatalf("list index = %d", result.SessionListModel.Index())
 	}
 
 	_, cmd := result.handleSessionsKeys("enter")

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/lleontor705/cortex/internal/domain"
 	"github.com/lleontor705/cortex/internal/store/session"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -113,20 +115,31 @@ func TestHandleRecentKeysNavigation(t *testing.T) {
 func TestHandleObservationDetailKeysScroll(t *testing.T) {
 	m := New(&Deps{})
 	m.Screen = ScreenObservationDetail
-	m.SelectedObservation = &domain.Observation{ID: 1}
+	m.Width, m.Height = 120, 40
+	m.SelectedObservation = &domain.Observation{ID: 1, Content: "line1\nline2\nline3"}
+
+	// Set up the viewport with content that can scroll
+	longContent := ""
+	for i := 0; i < 100; i++ {
+		longContent += fmt.Sprintf("line %d\n", i)
+	}
+	contentStr := buildDetailContent(m.SelectedObservation, nil, nil, nil)
+	_ = contentStr // content built from observation
+	m.DetailViewport = viewport.New(80, 10)
+	m.DetailViewport.SetContent(longContent)
 
 	// Scroll down
 	updated, _ := m.handleObservationDetailKeys("j")
 	result := updated.(Model)
-	if result.DetailScroll != 1 {
-		t.Fatalf("scroll = %d, want 1", result.DetailScroll)
+	if result.DetailViewport.YOffset < 1 {
+		t.Fatalf("viewport YOffset = %d, want >= 1", result.DetailViewport.YOffset)
 	}
 
 	// Scroll up
 	updated, _ = result.handleObservationDetailKeys("k")
 	result = updated.(Model)
-	if result.DetailScroll != 0 {
-		t.Fatalf("scroll = %d, want 0", result.DetailScroll)
+	if result.DetailViewport.YOffset != 0 {
+		t.Fatalf("viewport YOffset = %d, want 0", result.DetailViewport.YOffset)
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/lleontor705/cortex/internal/domain"
 )
 
 // ─── Logo ───────────────────────────────────────────────────────────────────
@@ -319,34 +321,37 @@ func (m Model) viewSearchResults() string {
 		return b.String()
 	}
 
-	visibleItems := (m.Height - 10) / 2
-	if visibleItems < 3 {
-		visibleItems = 3
+	if m.PreviewVisible && m.Width >= 100 {
+		listWidth := m.Width * 2 / 5
+		previewWidth := m.Width - listWidth - 5
+
+		listContent := m.SearchListModel.View()
+		listPane := lipgloss.NewStyle().
+			Width(listWidth).
+			Height(m.Height - 8).
+			Render(listContent)
+
+		previewContent := m.PreviewViewport.View()
+		scrollPct := fmt.Sprintf(" %3.f%% ", m.PreviewViewport.ScrollPercent()*100)
+		previewPane := lipgloss.NewStyle().
+			Width(previewWidth).
+			Height(m.Height - 8).
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(colorOverlay).
+			PaddingLeft(1).
+			Render(previewContent + "\n" + timestampStyle.Render(scrollPct))
+
+		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane))
+	} else {
+		b.WriteString(m.SearchListModel.View())
 	}
 
-	end := m.Scroll + visibleItems
-	if end > resultCount {
-		end = resultCount
+	helpText := "  j/k navigate • enter detail • t timeline • d delete • f filter"
+	if m.Width >= 100 {
+		helpText += " • p preview"
 	}
-
-	scoreStyle := lipgloss.NewStyle().Foreground(colorSubtext)
-	for i := m.Scroll; i < end; i++ {
-		r := m.SearchResults[i]
-		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, nil))
-		scoreInfo := fmt.Sprintf("     score: %.0f%%", r.Rank*100)
-		if r.ScoreBreakdown.Strategy != "" {
-			scoreInfo += fmt.Sprintf("  strategy: %s", r.ScoreBreakdown.Strategy)
-		}
-		b.WriteString(scoreStyle.Render(scoreInfo))
-		b.WriteString("\n")
-	}
-
-	if resultCount > visibleItems {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, resultCount)))
-	}
-
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • / search • esc back"))
+	helpText += " • / search • esc back"
+	b.WriteString(helpStyle.Render("\n" + helpText))
 
 	return b.String()
 }
@@ -371,27 +376,37 @@ func (m Model) viewRecent() string {
 		return b.String()
 	}
 
-	visibleItems := (m.Height - 8) / 2
-	if visibleItems < 3 {
-		visibleItems = 3
+	if m.PreviewVisible && m.Width >= 100 {
+		listWidth := m.Width * 2 / 5
+		previewWidth := m.Width - listWidth - 5
+
+		listContent := m.RecentList.View()
+		listPane := lipgloss.NewStyle().
+			Width(listWidth).
+			Height(m.Height - 8).
+			Render(listContent)
+
+		previewContent := m.PreviewViewport.View()
+		scrollPct := fmt.Sprintf(" %3.f%% ", m.PreviewViewport.ScrollPercent()*100)
+		previewPane := lipgloss.NewStyle().
+			Width(previewWidth).
+			Height(m.Height - 8).
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(colorOverlay).
+			PaddingLeft(1).
+			Render(previewContent + "\n" + timestampStyle.Render(scrollPct))
+
+		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane))
+	} else {
+		b.WriteString(m.RecentList.View())
 	}
 
-	end := m.Scroll + visibleItems
-	if end > count {
-		end = count
+	helpText := "  j/k navigate • enter detail • t timeline • d delete • f filter"
+	if m.Width >= 100 {
+		helpText += " • p preview"
 	}
-
-	for i := m.Scroll; i < end; i++ {
-		o := m.RecentObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, nil))
-	}
-
-	if count > visibleItems {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
-	}
-
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • esc back"))
+	helpText += " • esc back"
+	b.WriteString(helpStyle.Render("\n" + helpText))
 
 	return b.String()
 }
@@ -515,45 +530,7 @@ func (m Model) viewSessions() string {
 		return b.String()
 	}
 
-	visibleItems := m.Height - 8
-	if visibleItems < 5 {
-		visibleItems = 5
-	}
-
-	end := m.Scroll + visibleItems
-	if end > count {
-		end = count
-	}
-
-	for i := m.Scroll; i < end; i++ {
-		s := m.Sessions[i]
-		cursor := "  "
-		style := listItemStyle
-		if i == m.Cursor {
-			cursor = "▸ "
-			style = listSelectedStyle
-		}
-
-		summary := ""
-		if s.Session.Summary != "" {
-			summary = truncateStr(s.Session.Summary, 50)
-		}
-
-		line := fmt.Sprintf("%s%s  %s  %s obs  %s",
-			cursor,
-			projectStyle.Render(fmt.Sprintf("%-20s", s.Session.Project)),
-			timestampStyle.Render(formatTime(s.Session.StartedAt)),
-			statNumberStyle.Render(fmt.Sprintf("%d", s.ObservationCount)),
-			style.Render(summary))
-
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-
-	if count > visibleItems {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
-	}
+	b.WriteString(m.SessionListModel.View())
 
 	b.WriteString(helpStyle.Render("\n  j/k navigate • enter view session • esc back"))
 
@@ -577,11 +554,30 @@ func (m Model) viewSessionDetail() string {
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
+	// Session info table
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(colorOverlay)).
+		Headers("Field", "Value").
+		Row("Project", sess.Session.Project).
+		Row("Started", formatTime(sess.Session.StartedAt)).
+		Row("Observations", fmt.Sprintf("%d", sess.ObservationCount)).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return lipgloss.NewStyle().Bold(true).Foreground(colorCyan).Padding(0, 1)
+			}
+			if col == 0 {
+				return lipgloss.NewStyle().Foreground(colorPurple).Padding(0, 1)
+			}
+			return lipgloss.NewStyle().Foreground(colorText).Padding(0, 1)
+		})
+
 	if sess.Session.Summary != "" {
-		fmt.Fprintf(&b, "  %s %s\n\n",
-			detailLabelStyle.Render("Summary:"),
-			detailValueStyle.Render(sess.Session.Summary))
+		t = t.Row("Summary", truncateStr(sess.Session.Summary, 60))
 	}
+
+	b.WriteString(t.Render())
+	b.WriteString("\n\n")
 
 	count := len(m.SessionObservations)
 	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Observations (%d)", count)))
@@ -742,8 +738,34 @@ func (m Model) viewGraph() string {
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
-	// Show edges summary
-	if len(m.GraphEdges) > 0 {
+	// Show edges as a table (up to 20) or summary counts if more
+	if len(m.GraphEdges) > 0 && len(m.GraphEdges) <= 20 {
+		et := table.New().
+			Border(lipgloss.NormalBorder()).
+			BorderStyle(lipgloss.NewStyle().Foreground(colorOverlay)).
+			Headers("From", "Relation", "To", "Weight").
+			StyleFunc(func(row, col int) lipgloss.Style {
+				if row == table.HeaderRow {
+					return lipgloss.NewStyle().Bold(true).Foreground(colorCyan).Padding(0, 1)
+				}
+				if col == 1 {
+					return lipgloss.NewStyle().Foreground(colorMauve).Bold(true).Padding(0, 1)
+				}
+				return lipgloss.NewStyle().Foreground(colorText).Padding(0, 1)
+			})
+
+		for _, e := range m.GraphEdges {
+			et = et.Row(
+				fmt.Sprintf("#%d", e.FromObsID),
+				e.RelationType,
+				fmt.Sprintf("#%d", e.ToObsID),
+				fmt.Sprintf("%.1f", e.Weight),
+			)
+		}
+
+		b.WriteString(et.Render())
+		b.WriteString("\n\n")
+	} else if len(m.GraphEdges) > 20 {
 		edgeCounts := make(map[string]int)
 		for _, e := range m.GraphEdges {
 			edgeCounts[e.RelationType]++
@@ -752,7 +774,7 @@ func (m Model) viewGraph() string {
 		for rel, count := range edgeCounts {
 			parts = append(parts, fmt.Sprintf("%s: %d", rel, count))
 		}
-		fmt.Fprintf(&b, "  %s\n\n", timestampStyle.Render(strings.Join(parts, " • ")))
+		fmt.Fprintf(&b, "  %s\n\n", timestampStyle.Render(strings.Join(parts, " | ")))
 	}
 
 	count := len(m.GraphObservations)
@@ -763,60 +785,7 @@ func (m Model) viewGraph() string {
 		return b.String()
 	}
 
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Related Observations (%d)", count)))
-	b.WriteString("\n")
-
-	visibleItems := (m.Height - 12) / 2
-	if visibleItems < 3 {
-		visibleItems = 3
-	}
-
-	end := m.Scroll + visibleItems
-	if end > count {
-		end = count
-	}
-
-	for i := m.Scroll; i < end; i++ {
-		o := m.GraphObservations[i]
-
-		// Find the edge connecting this observation to root
-		edgeLabel := ""
-		for _, e := range m.GraphEdges {
-			if e.FromObsID == o.ID || e.ToObsID == o.ID {
-				edgeLabel = e.RelationType
-				break
-			}
-		}
-
-		cursor := "  "
-		style := listItemStyle
-		if i == m.Cursor {
-			cursor = "▸ "
-			style = listSelectedStyle
-		}
-
-		line := fmt.Sprintf("%s%s %s %s",
-			cursor,
-			idStyle.Render(fmt.Sprintf("#%-5d", o.ID)),
-			typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", o.Type)),
-			style.Render(truncateStr(o.Title, 45)))
-
-		if edgeLabel != "" {
-			line += "  " + graphEdgeStyle.Render("["+edgeLabel+"]")
-		}
-
-		b.WriteString(line + "\n")
-
-		preview := truncateStr(o.Content, 70)
-		if preview != "" {
-			b.WriteString(contentPreviewStyle.Render(preview) + "\n")
-		}
-	}
-
-	if count > visibleItems {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
-	}
+	b.WriteString(m.GraphListModel.View())
 
 	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • r re-root • esc back"))
 
@@ -843,25 +812,7 @@ func (m Model) viewArchive() string {
 		return b.String()
 	}
 
-	visibleItems := (m.Height - 8) / 2
-	if visibleItems < 3 {
-		visibleItems = 3
-	}
-
-	end := m.Scroll + visibleItems
-	if end > count {
-		end = count
-	}
-
-	for i := m.Scroll; i < end; i++ {
-		o := m.ArchivedObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, &archivedStyle))
-	}
-
-	if count > visibleItems {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
-	}
+	b.WriteString(m.ArchiveList.View())
 
 	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • u unarchive • d delete • f filter • esc back"))
 
@@ -912,16 +863,7 @@ func (m Model) viewHealth() string {
 		b.WriteString(listItemStyle.Render("  None — all high-score observations accessed recently"))
 		b.WriteString("\n")
 	} else {
-		for i, o := range m.HealthStale {
-			if i >= 5 {
-				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more", len(m.HealthStale)-5)))
-				break
-			}
-			fmt.Fprintf(&b, "  %s %s  %s\n",
-				idStyle.Render(fmt.Sprintf("#%-5d", o.ID)),
-				typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", o.Type)),
-				listItemStyle.Render(truncateStr(o.Title, 50)))
-		}
+		b.WriteString(renderHealthTable(m.HealthStale))
 	}
 	b.WriteString("\n")
 
@@ -932,16 +874,7 @@ func (m Model) viewHealth() string {
 		b.WriteString(listItemStyle.Render("  None — all observations are connected via graph"))
 		b.WriteString("\n")
 	} else {
-		for i, o := range m.HealthOrphans {
-			if i >= 5 {
-				fmt.Fprintf(&b, "    %s\n", timestampStyle.Render(fmt.Sprintf("...and %d more", len(m.HealthOrphans)-5)))
-				break
-			}
-			fmt.Fprintf(&b, "  %s %s  %s\n",
-				idStyle.Render(fmt.Sprintf("#%-5d", o.ID)),
-				typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", o.Type)),
-				listItemStyle.Render(truncateStr(o.Title, 50)))
-		}
+		b.WriteString(renderHealthTable(m.HealthOrphans))
 	}
 	b.WriteString("\n")
 
@@ -965,6 +898,44 @@ func (m Model) viewHealth() string {
 	b.WriteString(helpStyle.Render("\n  j/k scroll • tab section • enter expand/collapse • esc back"))
 
 	return b.String()
+}
+
+// renderHealthTable renders a table of observations for the health screen.
+func renderHealthTable(observations []*domain.Observation) string {
+	if len(observations) == 0 {
+		return "  No items\n"
+	}
+
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(colorOverlay)).
+		Headers("ID", "Type", "Title", "Project", "Created").
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return lipgloss.NewStyle().Bold(true).Foreground(colorCyan).Padding(0, 1)
+			}
+			return lipgloss.NewStyle().Foreground(colorText).Padding(0, 1)
+		})
+
+	limit := 10
+	for i, o := range observations {
+		if i >= limit {
+			break
+		}
+		t = t.Row(
+			fmt.Sprintf("#%d", o.ID),
+			o.Type,
+			truncateStr(o.Title, 35),
+			o.Project,
+			formatTime(o.CreatedAt),
+		)
+	}
+
+	result := t.Render()
+	if len(observations) > limit {
+		result += fmt.Sprintf("\n  %s", timestampStyle.Render(fmt.Sprintf("...and %d more", len(observations)-limit)))
+	}
+	return result + "\n"
 }
 
 // ─── Status Bar ─────────────────────────────────────────────────────────────
@@ -1013,27 +984,27 @@ func (m Model) renderStatusBar() string {
 	nameStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Background(lipgloss.Color("#1a1b2e"))
 	parts = append(parts, nameStyle.Render(m.screenName()))
 
-	// List position
+	// List position (from bubbles/list components)
 	switch m.Screen {
 	case ScreenRecent:
-		if len(m.RecentObservations) > 0 {
-			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.RecentObservations)))
+		if len(m.RecentList.Items()) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.RecentList.Index()+1, len(m.RecentList.Items())))
 		}
 	case ScreenSearchResults:
-		if len(m.SearchResults) > 0 {
-			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.SearchResults)))
+		if len(m.SearchListModel.Items()) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.SearchListModel.Index()+1, len(m.SearchListModel.Items())))
 		}
 	case ScreenSessions:
-		if len(m.Sessions) > 0 {
-			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.Sessions)))
+		if len(m.SessionListModel.Items()) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.SessionListModel.Index()+1, len(m.SessionListModel.Items())))
 		}
 	case ScreenGraph:
-		if len(m.GraphObservations) > 0 {
-			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.GraphObservations)))
+		if len(m.GraphListModel.Items()) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.GraphListModel.Index()+1, len(m.GraphListModel.Items())))
 		}
 	case ScreenArchive:
-		if len(m.ArchivedObservations) > 0 {
-			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.ArchivedObservations)))
+		if len(m.ArchiveList.Items()) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.ArchiveList.Index()+1, len(m.ArchiveList.Items())))
 		}
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -10,7 +10,19 @@ import (
 
 // ─── Logo ───────────────────────────────────────────────────────────────────
 
-func renderLogo(version string) string {
+func (m Model) renderLogo() string {
+	// Compact logo for small terminals (width < 60 or height < 25)
+	if m.Width > 0 && (m.Width < 60 || m.Height < 25) {
+		compactStyle := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorOverlay).
+			Padding(0, 1).
+			MarginBottom(1)
+		title := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Render("CORTEX")
+		tagline := lipgloss.NewStyle().Foreground(colorSubtext).Italic(true).Render(" " + m.Version + " — your brain never forgets")
+		return compactStyle.Render(title + tagline) + "\n"
+	}
+
 	logoText := []string{
 		` ██████  ██████  ██████  ████████ ███████ ██   ██ `,
 		`██      ██    ██ ██   ██    ██    ██       ██ ██  `,
@@ -45,7 +57,7 @@ func renderLogo(version string) string {
 	}
 	b.WriteString("\n")
 
-	b.WriteString(taglineStyle.Render(" > cortex " + version + " — your brain never forgets"))
+	b.WriteString(taglineStyle.Render(" > cortex " + m.Version + " — your brain never forgets"))
 
 	return frameStyle.Render(b.String()) + "\n"
 }
@@ -82,6 +94,8 @@ func (m Model) View() string {
 		content = m.viewHealth()
 	case ScreenEmbeddingConfig:
 		content = m.viewEmbeddingConfig()
+	case ScreenHelp:
+		content = m.viewHelp()
 	default:
 		content = "Unknown screen"
 	}
@@ -90,7 +104,36 @@ func (m Model) View() string {
 		content += "\n" + errorStyle.Render("Error: "+m.ErrorMsg)
 	}
 
-	return appStyle.Render(content)
+	// Toast message
+	if m.ToastMessage != "" {
+		var prefix string
+		switch m.ToastType {
+		case "warning":
+			prefix = lipgloss.NewStyle().Foreground(colorAmber).Bold(true).Render("  ! ")
+		case "error":
+			prefix = lipgloss.NewStyle().Foreground(colorRed).Bold(true).Render("  x ")
+		default:
+			prefix = lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render("  v ")
+		}
+		content += "\n" + prefix + lipgloss.NewStyle().Foreground(colorText).Render(m.ToastMessage)
+	}
+
+	// Delete confirmation modal
+	if m.ConfirmDelete {
+		title := m.DeleteTargetTitle
+		if len(title) > 40 {
+			title = title[:40] + "..."
+		}
+		modal := fmt.Sprintf("  Delete observation #%d %q?\n\n  Press [y] to confirm, any other key to cancel", m.ConfirmDeleteID, title)
+		content += "\n" + modalStyle.Render(modal)
+	}
+
+	rendered := appStyle.Render(content)
+
+	// Status bar at the bottom
+	rendered += "\n" + m.renderStatusBar()
+
+	return rendered
 }
 
 // ─── Dashboard ──────────────────────────────────────────────────────────────
@@ -98,7 +141,7 @@ func (m Model) View() string {
 func (m Model) viewDashboard() string {
 	var b strings.Builder
 
-	b.WriteString(renderLogo(m.Version))
+	b.WriteString(m.renderLogo())
 	b.WriteString("\n")
 
 	// Update notification
@@ -161,7 +204,7 @@ func (m Model) viewDashboard() string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter select • s search • q quit"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter select • s search • ? help • q quit"))
 
 	return b.String()
 }
@@ -192,6 +235,9 @@ func (m Model) viewSearchResults() string {
 	if resultCount != 1 {
 		header += "s"
 	}
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -212,9 +258,16 @@ func (m Model) viewSearchResults() string {
 		end = resultCount
 	}
 
+	scoreStyle := lipgloss.NewStyle().Foreground(colorSubtext)
 	for i := m.Scroll; i < end; i++ {
 		r := m.SearchResults[i]
 		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, nil))
+		scoreInfo := fmt.Sprintf("     score: %.0f%%", r.Rank*100)
+		if r.ScoreBreakdown.Strategy != "" {
+			scoreInfo += fmt.Sprintf("  strategy: %s", r.ScoreBreakdown.Strategy)
+		}
+		b.WriteString(scoreStyle.Render(scoreInfo))
+		b.WriteString("\n")
 	}
 
 	if resultCount > visibleItems {
@@ -222,7 +275,7 @@ func (m Model) viewSearchResults() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, resultCount)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • / search • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • / search • esc back"))
 
 	return b.String()
 }
@@ -234,6 +287,9 @@ func (m Model) viewRecent() string {
 
 	count := len(m.RecentObservations)
 	header := fmt.Sprintf("  Recent Observations — %d total", count)
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -264,7 +320,7 @@ func (m Model) viewRecent() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • d delete • f filter • esc back"))
 
 	return b.String()
 }
@@ -277,7 +333,11 @@ func (m Model) viewObservationDetail() string {
 	if m.SelectedObservation == nil {
 		b.WriteString(headerStyle.Render("  Observation Detail"))
 		b.WriteString("\n")
-		b.WriteString(noResultsStyle.Render("Loading..."))
+		if m.DetailLoading {
+			b.WriteString(noResultsStyle.Render(m.SetupSpinner.View() + " Loading observation..."))
+		} else {
+			b.WriteString(noResultsStyle.Render("Loading..."))
+		}
 		return b.String()
 	}
 
@@ -390,7 +450,7 @@ func (m Model) viewObservationDetail() string {
 			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", scroll+1, end, len(contentLines))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • g graph • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • g graph • s session • d delete • esc back"))
 
 	return b.String()
 }
@@ -794,6 +854,9 @@ func (m Model) viewArchive() string {
 
 	count := len(m.ArchivedObservations)
 	header := fmt.Sprintf("  Archived Observations — %d total", count)
+	if m.FilterProject != "" {
+		header += fmt.Sprintf(" (project: %s)", m.FilterProject)
+	}
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
@@ -824,7 +887,7 @@ func (m Model) viewArchive() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count)))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • u unarchive • d delete • f filter • esc back"))
 
 	return b.String()
 }
@@ -861,8 +924,13 @@ func (m Model) viewHealth() string {
 	b.WriteString(statCardStyle.Render(statsContent))
 	b.WriteString("\n")
 
-	// Stale observations
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Stale Observations (%d)", len(m.HealthStale))))
+	// Stale observations — tab-style header
+	tabStyle := lipgloss.NewStyle().Background(colorAmber).Foreground(lipgloss.Color("#16161e")).Bold(true).Padding(0, 1)
+	tabActiveStyle := lipgloss.NewStyle().Background(colorCyan).Foreground(lipgloss.Color("#16161e")).Bold(true).Padding(0, 1)
+	tabRedStyle := lipgloss.NewStyle().Background(colorRed).Foreground(lipgloss.Color("#16161e")).Bold(true).Padding(0, 1)
+
+	_ = tabActiveStyle // used below
+	b.WriteString("  " + tabStyle.Render(fmt.Sprintf("Stale (%d)", len(m.HealthStale))))
 	b.WriteString("\n")
 	if len(m.HealthStale) == 0 {
 		b.WriteString(listItemStyle.Render("  None — all high-score observations accessed recently"))
@@ -881,8 +949,8 @@ func (m Model) viewHealth() string {
 	}
 	b.WriteString("\n")
 
-	// Orphan observations
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Orphan Observations (%d)", len(m.HealthOrphans))))
+	// Orphan observations — tab-style header
+	b.WriteString("  " + tabRedStyle.Render(fmt.Sprintf("Orphans (%d)", len(m.HealthOrphans))))
 	b.WriteString("\n")
 	if len(m.HealthOrphans) == 0 {
 		b.WriteString(listItemStyle.Render("  None — all observations are connected via graph"))
@@ -901,8 +969,8 @@ func (m Model) viewHealth() string {
 	}
 	b.WriteString("\n")
 
-	// Consolidation candidates
-	b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Consolidation Candidates (%d)", len(m.HealthCandidates))))
+	// Consolidation candidates — tab-style header
+	b.WriteString("  " + tabActiveStyle.Render(fmt.Sprintf("Consolidation (%d)", len(m.HealthCandidates))))
 	b.WriteString("\n")
 	if len(m.HealthCandidates) == 0 {
 		b.WriteString(listItemStyle.Render("  None — no duplicate topic keys found"))
@@ -918,7 +986,177 @@ func (m Model) viewHealth() string {
 		}
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k scroll • tab section • enter expand/collapse • esc back"))
+
+	return b.String()
+}
+
+// ─── Status Bar ─────────────────────────────────────────────────────────────
+
+func (m Model) screenName() string {
+	switch m.Screen {
+	case ScreenDashboard:
+		return "Dashboard"
+	case ScreenSearch:
+		return "Search"
+	case ScreenSearchResults:
+		return "Search Results"
+	case ScreenRecent:
+		return "Recent"
+	case ScreenObservationDetail:
+		return "Detail"
+	case ScreenTimeline:
+		return "Timeline"
+	case ScreenSessions:
+		return "Sessions"
+	case ScreenSessionDetail:
+		return "Session Detail"
+	case ScreenSetup:
+		return "Setup"
+	case ScreenGraph:
+		return "Graph"
+	case ScreenArchive:
+		return "Archive"
+	case ScreenHealth:
+		return "Health"
+	case ScreenEmbeddingConfig:
+		return "Embedding Settings"
+	case ScreenHelp:
+		return "Help"
+	default:
+		return "Cortex"
+	}
+}
+
+func (m Model) renderStatusBar() string {
+	var parts []string
+
+	// Screen name
+	nameStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Background(lipgloss.Color("#1a1b2e"))
+	parts = append(parts, nameStyle.Render(m.screenName()))
+
+	// List position
+	switch m.Screen {
+	case ScreenRecent:
+		if len(m.RecentObservations) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.RecentObservations)))
+		}
+	case ScreenSearchResults:
+		if len(m.SearchResults) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.SearchResults)))
+		}
+	case ScreenSessions:
+		if len(m.Sessions) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.Sessions)))
+		}
+	case ScreenGraph:
+		if len(m.GraphObservations) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.GraphObservations)))
+		}
+	case ScreenArchive:
+		if len(m.ArchivedObservations) > 0 {
+			parts = append(parts, fmt.Sprintf("[%d/%d]", m.Cursor+1, len(m.ArchivedObservations)))
+		}
+	}
+
+	// Observation count
+	if m.Stats != nil {
+		parts = append(parts, fmt.Sprintf("%d obs", m.Stats.TotalObservations))
+	}
+
+	// Version
+	if m.Version != "" {
+		parts = append(parts, m.Version)
+	}
+
+	// Help hint
+	parts = append(parts, "? help")
+
+	barContent := strings.Join(parts, "  |  ")
+	width := m.Width
+	if width < 20 {
+		width = 80
+	}
+	return statusBarStyle.Width(width).Render(barContent)
+}
+
+// ─── Help Screen ────────────────────────────────────────────────────────────
+
+func (m Model) viewHelp() string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("  Cortex TUI — Keyboard Reference"))
+	b.WriteString("\n\n")
+
+	section := func(title string, bindings [][2]string) {
+		b.WriteString(sectionHeadingStyle.Render("  "+title))
+		b.WriteString("\n")
+		keyStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Width(16)
+		descStyle := lipgloss.NewStyle().Foreground(colorText)
+		for _, bind := range bindings {
+			fmt.Fprintf(&b, "  %s %s\n", keyStyle.Render(bind[0]), descStyle.Render(bind[1]))
+		}
+		b.WriteString("\n")
+	}
+
+	section("Global", [][2]string{
+		{"?", "Toggle this help screen"},
+		{"q / esc", "Go back / quit"},
+		{"ctrl+c", "Force quit"},
+	})
+
+	section("Navigation", [][2]string{
+		{"j / down", "Move cursor down"},
+		{"k / up", "Move cursor up"},
+		{"G", "Jump to last item"},
+		{"gg", "Jump to first item"},
+		{"enter", "Select / open"},
+		{"s / /", "Open search"},
+		{"f", "Cycle project filter"},
+	})
+
+	section("List Screens (Recent, Search Results)", [][2]string{
+		{"enter", "View observation detail"},
+		{"t", "View timeline"},
+		{"d", "Delete observation (with confirm)"},
+		{"f", "Cycle project filter"},
+	})
+
+	section("Detail View", [][2]string{
+		{"j / k", "Scroll content"},
+		{"t", "View timeline"},
+		{"g", "View graph connections"},
+		{"s", "Jump to session"},
+		{"d", "Delete observation (with confirm)"},
+	})
+
+	section("Graph", [][2]string{
+		{"enter", "View observation detail"},
+		{"r", "Re-root graph on selection"},
+	})
+
+	section("Health", [][2]string{
+		{"j / k", "Scroll dashboard"},
+		{"tab", "Cycle section"},
+		{"enter", "Expand/collapse section"},
+	})
+
+	section("Archive", [][2]string{
+		{"enter", "View observation detail"},
+		{"u", "Unarchive (restore) observation"},
+		{"d", "Delete observation (with confirm)"},
+		{"f", "Cycle project filter"},
+	})
+
+	section("Embedding Settings", [][2]string{
+		{"h / l", "Cycle provider"},
+		{"space", "Toggle checkbox"},
+		{"enter", "Edit model name / save"},
+		{"r", "Reload config from disk"},
+		{"x", "Reindex all embeddings (after save)"},
+	})
+
+	b.WriteString(helpStyle.Render("  Press esc / q / ? to close"))
 
 	return b.String()
 }
@@ -941,10 +1179,14 @@ func (m Model) renderObservationListItem(index int, id int64, obsType, title, co
 		proj = "  " + projectStyle.Render(project)
 	}
 
+	// Use type-specific color for the badge
+	tColor := typeColor(obsType)
+	typeBadge := lipgloss.NewStyle().Foreground(tColor).Bold(true).Render(fmt.Sprintf("[%-12s]", obsType))
+
 	line := fmt.Sprintf("%s%s %s %s%s  %s\n",
 		cursor,
 		idStyle.Render(fmt.Sprintf("#%-5d", id)),
-		typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", obsType)),
+		typeBadge,
 		style.Render(truncateStr(title, 50)),
 		proj,
 		timestampStyle.Render(formatTime(createdAt)))
@@ -997,7 +1239,13 @@ func (m Model) viewEmbeddingConfig() string {
 	var b strings.Builder
 
 	b.WriteString(headerStyle.Render("  Embedding Settings"))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	if m.EmbCfgDirty {
+		b.WriteString("  " + lipgloss.NewStyle().Foreground(colorAmber).Render("* Unsaved changes"))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
 
 	providers := []string{"none", "ollama", "openai"}
 	focusMarker := func(field int) string {
@@ -1065,6 +1313,22 @@ func (m Model) viewEmbeddingConfig() string {
 
 	if m.EmbCfgSaved {
 		b.WriteString("\n  " + lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render("Configuration saved."))
+
+		// Reindex warning (amber)
+		if m.EmbCfgReindexWarning {
+			b.WriteString("\n\n  " + lipgloss.NewStyle().Foreground(colorAmber).Bold(true).Render("! Provider/model changed — existing embeddings may be stale."))
+			b.WriteString("\n  " + lipgloss.NewStyle().Foreground(colorSubtext).Render("Press [x] to reindex all observations with the new model."))
+		}
+
+		// Reindexing spinner
+		if m.EmbCfgReindexing {
+			b.WriteString("\n\n  " + m.EmbCfgSpinner.View() + " Reindexing all observations...")
+		}
+
+		// Reindex complete (green)
+		if m.EmbCfgReindexProgress != "" {
+			b.WriteString("\n\n  " + lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render(m.EmbCfgReindexProgress))
+		}
 
 		// Ollama status section
 		if m.EmbCfgProvider == 1 {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -64,6 +64,11 @@ func (m Model) renderLogo() string {
 
 // ─── View (main router) ────────────────────────────────────────────────────
 
+// isCompact returns true when the terminal is too small for full layout.
+func (m Model) isCompact() bool {
+	return m.Width < 60 || m.Height < 20
+}
+
 func (m Model) View() string {
 	var content string
 
@@ -118,14 +123,30 @@ func (m Model) View() string {
 		content += "\n" + prefix + lipgloss.NewStyle().Foreground(colorText).Render(m.ToastMessage)
 	}
 
-	// Delete confirmation modal
+	// Delete confirmation modal (centered overlay)
 	if m.ConfirmDelete {
 		title := m.DeleteTargetTitle
-		if len(title) > 40 {
-			title = title[:40] + "..."
+		if len(title) > 35 {
+			title = title[:35] + "..."
 		}
-		modal := fmt.Sprintf("  Delete observation #%d %q?\n\n  Press [y] to confirm, any other key to cancel", m.ConfirmDeleteID, title)
-		content += "\n" + modalStyle.Render(modal)
+		modalContent := fmt.Sprintf("Delete %q?\n\n  [y] Yes    [n] No", title)
+		modal := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorAmber).
+			Foreground(colorText).
+			Padding(1, 3).
+			Width(50).
+			Render(modalContent)
+
+		// Overlay on top of content using Place
+		content = lipgloss.Place(m.Width-4, m.Height-2,
+			lipgloss.Center, lipgloss.Center,
+			modal)
+	}
+
+	// Command palette overlay
+	if m.CmdPaletteOpen {
+		content = m.viewCmdPalette()
 	}
 
 	rendered := appStyle.Render(content)
@@ -191,6 +212,13 @@ func (m Model) viewDashboard() string {
 		b.WriteString("\n")
 	}
 
+	// 7-day activity sparkline
+	if len(m.ActivityData) > 0 {
+		sparkline := renderSparkline(m.ActivityData)
+		b.WriteString(sparkline)
+		b.WriteString("\n")
+	}
+
 	// Menu
 	b.WriteString(titleStyle.Render("  Actions"))
 	b.WriteString("\n")
@@ -204,9 +232,52 @@ func (m Model) viewDashboard() string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter select • s search • ? help • q quit"))
+	if m.isCompact() {
+		b.WriteString(helpStyle.Render("\n  j/k • enter • s search • q quit"))
+	} else {
+		b.WriteString(helpStyle.Render("\n  j/k navigate • enter select • s search • ? help • q quit"))
+	}
 
 	return b.String()
+}
+
+// renderSparkline renders a 7-day activity sparkline with block characters.
+func renderSparkline(data []int) string {
+	blocks := []rune{'\u2581', '\u2582', '\u2583', '\u2584', '\u2585', '\u2586', '\u2587', '\u2588'}
+
+	maxVal := 0
+	for _, v := range data {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	if maxVal == 0 {
+		maxVal = 1
+	}
+
+	var spark strings.Builder
+	for _, v := range data {
+		idx := (v * (len(blocks) - 1)) / maxVal
+		if idx >= len(blocks) {
+			idx = len(blocks) - 1
+		}
+		spark.WriteRune(blocks[idx])
+	}
+
+	labelStyle := lipgloss.NewStyle().Foreground(colorSubtext)
+	sparkStyle := lipgloss.NewStyle().Foreground(colorCyan)
+	countStyle := lipgloss.NewStyle().Foreground(colorSubtext)
+
+	// Sum total
+	total := 0
+	for _, v := range data {
+		total += v
+	}
+
+	return fmt.Sprintf("  %s %s %s",
+		labelStyle.Render("7-day activity:"),
+		sparkStyle.Render(spark.String()),
+		countStyle.Render(fmt.Sprintf("(%d total)", total)))
 }
 
 // ─── Search ─────────────────────────────────────────────────────────────────
@@ -347,110 +418,15 @@ func (m Model) viewObservationDetail() string {
 	b.WriteString(headerStyle.Render(header))
 	b.WriteString("\n")
 
-	// Metadata rows
-	fmt.Fprintf(&b, "%s %s\n",
-		detailLabelStyle.Render("Type:"),
-		typeBadgeStyle.Render(obs.Type))
-
-	fmt.Fprintf(&b, "%s %s\n",
-		detailLabelStyle.Render("Title:"),
-		detailValueStyle.Bold(true).Render(obs.Title))
-
-	fmt.Fprintf(&b, "%s %s\n",
-		detailLabelStyle.Render("Session:"),
-		idStyle.Render(obs.SessionID))
-
-	fmt.Fprintf(&b, "%s %s\n",
-		detailLabelStyle.Render("Created:"),
-		timestampStyle.Render(formatTime(obs.CreatedAt)))
-
-	if obs.Project != "" {
-		fmt.Fprintf(&b, "%s %s\n",
-			detailLabelStyle.Render("Project:"),
-			projectStyle.Render(obs.Project))
-	}
-
-	// Cortex-exclusive: Importance Score
-	if m.DetailScore != nil {
-		scoreStr := fmt.Sprintf("%.1f/5.0", m.DetailScore.Score)
-		fmt.Fprintf(&b, "%s %s  (accessed %d times)\n",
-			detailLabelStyle.Render("Score:"),
-			scoreStyle(m.DetailScore.Score).Render(scoreStr),
-			m.DetailScore.AccessCount)
-	}
-
-	// Cortex-exclusive: Entity Links
-	if len(m.DetailEntities) > 0 {
-		b.WriteString("\n")
-		b.WriteString(sectionHeadingStyle.Render("  Entities"))
-		b.WriteString("\n")
-		for _, e := range m.DetailEntities {
-			icon := entityIcon(e.EntityType)
-			fmt.Fprintf(&b, "  %s %s\n",
-				entityStyle(e.EntityType).Render(icon+" "+e.EntityType),
-				detailValueStyle.Render(e.EntityValue))
-		}
-	}
-
-	// Cortex-exclusive: Knowledge Graph edges
-	if len(m.DetailEdges) > 0 {
-		b.WriteString("\n")
-		b.WriteString(sectionHeadingStyle.Render(fmt.Sprintf("  Related (%d links)", len(m.DetailEdges))))
-		b.WriteString("\n")
-		for _, e := range m.DetailEdges {
-			targetID := e.ToObsID
-			if targetID == obs.ID {
-				targetID = e.FromObsID
-			}
-			fmt.Fprintf(&b, "  %s #%d  %s\n",
-				graphEdgeStyle.Render("["+e.RelationType+"]"),
-				targetID,
-				timestampStyle.Render(fmt.Sprintf("weight: %.1f", e.Weight)))
-		}
-	}
-
-	// Content section
-	b.WriteString("\n")
-	b.WriteString(sectionHeadingStyle.Render("  Content"))
+	// Viewport handles all content rendering and scrolling
+	b.WriteString(m.DetailViewport.View())
 	b.WriteString("\n")
 
-	wrapWidth := m.Width - 6
-	if wrapWidth < 20 {
-		wrapWidth = 20
-	}
-	wrappedContent := detailContentStyle.Width(wrapWidth).Render(obs.Content)
+	// Scroll percentage indicator
+	scrollPct := fmt.Sprintf(" %3.f%% ", m.DetailViewport.ScrollPercent()*100)
+	b.WriteString(timestampStyle.Render(scrollPct))
 
-	contentLines := strings.Split(wrappedContent, "\n")
-	maxLines := m.Height - 22 // More room needed for enriched detail
-	if maxLines < 5 {
-		maxLines = 5
-	}
-
-	maxScroll := len(contentLines) - maxLines
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	scroll := m.DetailScroll
-	if scroll > maxScroll {
-		scroll = maxScroll
-	}
-
-	end := scroll + maxLines
-	if end > len(contentLines) {
-		end = len(contentLines)
-	}
-
-	for i := scroll; i < end; i++ {
-		b.WriteString(contentLines[i])
-		b.WriteString("\n")
-	}
-
-	if len(contentLines) > maxLines {
-		fmt.Fprintf(&b, "\n  %s",
-			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", scroll+1, end, len(contentLines))))
-	}
-
-	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • g graph • s session • d delete • esc back"))
+	b.WriteString(helpStyle.Render("  j/k scroll • t timeline • g graph • s session • d delete • esc back"))
 
 	return b.String()
 }
@@ -1029,6 +1005,8 @@ func (m Model) screenName() string {
 }
 
 func (m Model) renderStatusBar() string {
+	compact := m.isCompact()
+
 	var parts []string
 
 	// Screen name
@@ -1059,17 +1037,25 @@ func (m Model) renderStatusBar() string {
 		}
 	}
 
-	// Observation count
+	if compact {
+		// Compact mode: just screen name + position
+		barContent := strings.Join(parts, "  |  ")
+		width := m.Width
+		if width < 20 {
+			width = 80
+		}
+		return statusBarStyle.Width(width).Render(barContent)
+	}
+
+	// Full mode: add observation count, version, help hint
 	if m.Stats != nil {
 		parts = append(parts, fmt.Sprintf("%d obs", m.Stats.TotalObservations))
 	}
 
-	// Version
 	if m.Version != "" {
 		parts = append(parts, m.Version)
 	}
 
-	// Help hint
 	parts = append(parts, "? help")
 
 	barContent := strings.Join(parts, "  |  ")
@@ -1081,6 +1067,45 @@ func (m Model) renderStatusBar() string {
 }
 
 // ─── Help Screen ────────────────────────────────────────────────────────────
+
+// ─── Command Palette ──────────────────────────────────────────────────────
+
+func (m Model) viewCmdPalette() string {
+	var b strings.Builder
+
+	filtered := m.filteredCommands()
+
+	b.WriteString("  " + m.CmdPaletteInput.View())
+	b.WriteString("\n\n")
+
+	for i, cmd := range filtered {
+		cursor := "  "
+		style := lipgloss.NewStyle().Foreground(colorText)
+		if i == m.CmdPaletteCursor {
+			cursor = "\u25b8 "
+			style = lipgloss.NewStyle().Foreground(lipgloss.Color("#16161e")).Background(colorCyan).Bold(true)
+		}
+
+		shortcut := ""
+		if cmd.shortcut != "" {
+			shortcut = lipgloss.NewStyle().Foreground(colorSubtext).Render("  " + cmd.shortcut)
+		}
+
+		b.WriteString(cursor + style.Render(cmd.name) + shortcut + "\n")
+	}
+
+	modalContent := b.String()
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorCyan).
+		Padding(1, 2).
+		Width(50).
+		Render(modalContent)
+
+	return lipgloss.Place(m.Width-4, m.Height-2,
+		lipgloss.Center, lipgloss.Center,
+		modal)
+}
 
 func (m Model) viewHelp() string {
 	var b strings.Builder
@@ -1320,9 +1345,14 @@ func (m Model) viewEmbeddingConfig() string {
 			b.WriteString("\n  " + lipgloss.NewStyle().Foreground(colorSubtext).Render("Press [x] to reindex all observations with the new model."))
 		}
 
-		// Reindexing spinner
+		// Reindexing spinner + progress bar
 		if m.EmbCfgReindexing {
 			b.WriteString("\n\n  " + m.EmbCfgSpinner.View() + " Reindexing all observations...")
+			pct := 0.0
+			if m.ReindexTotal > 0 {
+				pct = float64(m.ReindexDone) / float64(m.ReindexTotal)
+			}
+			b.WriteString("\n  " + m.ReindexProgressBar.ViewAs(pct))
 		}
 
 		// Reindex complete (green)

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/lleontor705/cortex/internal/setup"
 	"github.com/lleontor705/cortex/internal/store/session"
 	"github.com/lleontor705/cortex/internal/update"
+
+	"github.com/charmbracelet/bubbles/viewport"
 )
 
 // Type alias for cleaner test literals.
@@ -119,7 +121,7 @@ func TestViewRecent(t *testing.T) {
 func TestViewObservationDetailWithEnrichment(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
-	m.SelectedObservation = &domain.Observation{
+	obs := &domain.Observation{
 		ID:        42,
 		Type:      "bugfix",
 		Title:     "Fix N+1 query",
@@ -128,18 +130,27 @@ func TestViewObservationDetailWithEnrichment(t *testing.T) {
 		Project:   "cortex",
 		CreatedAt: time.Now(),
 	}
-	m.DetailScore = &domain.ImportanceScore{
+	score := &domain.ImportanceScore{
 		ObservationID: 42,
 		Score:         3.7,
 		AccessCount:   15,
 	}
-	m.DetailEntities = []*domain.EntityLink{
+	entities := []*domain.EntityLink{
 		{EntityType: "file", EntityValue: "store.go"},
 		{EntityType: "package", EntityValue: "sqlitestore"},
 	}
-	m.DetailEdges = []*domain.Edge{
+	edges := []*domain.Edge{
 		{FromObsID: 42, ToObsID: 43, RelationType: "references", Weight: 1.0},
 	}
+	m.SelectedObservation = obs
+	m.DetailScore = score
+	m.DetailEntities = entities
+	m.DetailEdges = edges
+
+	// Build viewport content as the update handler would
+	contentStr := buildDetailContent(obs, score, entities, edges)
+	m.DetailViewport = viewport.New(m.Width-4, m.Height-8)
+	m.DetailViewport.SetContent(contentStr)
 
 	output := m.viewObservationDetail()
 	if !strings.Contains(output, "3.7/5.0") {
@@ -410,10 +421,24 @@ func TestViewRecentSmallTerminal(t *testing.T) {
 func TestViewObservationDetailSmallTerminal(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 20, 10
-	m.SelectedObservation = &domain.Observation{
+	obs := &domain.Observation{
 		ID: 1, Type: "test", Title: "Title", Content: "Content content content",
 		CreatedAt: time.Now(),
 	}
+	m.SelectedObservation = obs
+
+	// Build viewport content as the update handler would
+	contentStr := buildDetailContent(obs, nil, nil, nil)
+	w := m.Width - 4
+	if w < 20 {
+		w = 20
+	}
+	h := m.Height - 8
+	if h < 5 {
+		h = 5
+	}
+	m.DetailViewport = viewport.New(w, h)
+	m.DetailViewport.SetContent(contentStr)
 
 	output := m.viewObservationDetail()
 	if output == "" {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lleontor705/cortex/internal/store/session"
 	"github.com/lleontor705/cortex/internal/update"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 )
 
@@ -74,9 +75,13 @@ func TestViewSearchResults(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
 	m.SearchQuery = "test"
-	m.SearchResults = []*domain.SearchResult{
+	results := []*domain.SearchResult{
 		{Observation: domain.Observation{ID: 1, Type: "bugfix", Title: "Fix bug", Content: "content", CreatedAt: time.Now()}},
 	}
+	m.SearchResults = results
+	items := []list.Item{searchResultItem{result: results[0]}}
+	m.SearchListModel.SetItems(items)
+	m.SearchListModel.SetSize(116, 30)
 
 	output := m.viewSearchResults()
 	if !strings.Contains(output, "test") {
@@ -105,9 +110,13 @@ func TestViewSearchResultsEmpty(t *testing.T) {
 func TestViewRecent(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
-	m.RecentObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Type: "decision", Title: "Use BubbleTea", Content: "TUI framework", CreatedAt: time.Now(), Project: "cortex"},
 	}
+	m.RecentObservations = obs
+	items := []list.Item{observationItem{obs: obs[0]}}
+	m.RecentList.SetItems(items)
+	m.RecentList.SetSize(116, 32)
 
 	output := m.viewRecent()
 	if !strings.Contains(output, "Recent Observations") {
@@ -196,12 +205,16 @@ func TestViewTimeline(t *testing.T) {
 func TestViewSessions(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
-	m.Sessions = []*session.SessionStats{
+	sessions := []*session.SessionStats{
 		{
 			Session:          &domain.Session{ID: "s1", Project: "cortex", StartedAt: time.Now(), Summary: "Test session"},
 			ObservationCount: 5,
 		},
 	}
+	m.Sessions = sessions
+	items := []list.Item{sessionItem{session: sessions[0]}}
+	m.SessionListModel.SetItems(items)
+	m.SessionListModel.SetSize(116, 32)
 
 	output := m.viewSessions()
 	if !strings.Contains(output, "Sessions") {
@@ -216,12 +229,17 @@ func TestViewGraph(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
 	m.GraphRootID = 1
-	m.GraphObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 2, Type: "decision", Title: "Related obs", Content: "related"},
 	}
-	m.GraphEdges = []*domain.Edge{
+	edges := []*domain.Edge{
 		{FromObsID: 1, ToObsID: 2, RelationType: "references", Weight: 1.0},
 	}
+	m.GraphObservations = obs
+	m.GraphEdges = edges
+	items := []list.Item{graphItem{obs: obs[0], edgeLabel: "references"}}
+	m.GraphListModel.SetItems(items)
+	m.GraphListModel.SetSize(116, 28)
 
 	output := m.viewGraph()
 	if !strings.Contains(output, "Knowledge Graph") {
@@ -241,9 +259,13 @@ func TestViewGraph(t *testing.T) {
 func TestViewArchive(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 120, 40
-	m.ArchivedObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Type: "old", Title: "Archived item", Content: "old content", CreatedAt: time.Now()},
 	}
+	m.ArchivedObservations = obs
+	items := []list.Item{observationItem{obs: obs[0]}}
+	m.ArchiveList.SetItems(items)
+	m.ArchiveList.SetSize(116, 32)
 
 	output := m.viewArchive()
 	if !strings.Contains(output, "Archived Observations") {
@@ -408,9 +430,13 @@ func TestViewDashboardSmallTerminal(t *testing.T) {
 func TestViewRecentSmallTerminal(t *testing.T) {
 	m := New(&Deps{})
 	m.Width, m.Height = 20, 10
-	m.RecentObservations = []*domain.Observation{
+	obs := []*domain.Observation{
 		{ID: 1, Type: "test", Title: "T", Content: "C", CreatedAt: time.Now()},
 	}
+	m.RecentObservations = obs
+	items := []list.Item{observationItem{obs: obs[0]}}
+	m.RecentList.SetItems(items)
+	m.RecentList.SetSize(16, 2)
 
 	output := m.viewRecent()
 	if output == "" {


### PR DESCRIPTION
## Summary
Comprehensive TUI overhaul: search bug fixes, advanced Bubbles components, professional UI/UX patterns.

### Search Fixes (6)
- Mutex on ollamaService/openAIService dims cache (race condition)
- Log embedding failures in mem_save goroutine and hybrid search
- Remove semantically incorrect FTS5 embedding proxy fallback
- Log dimension mismatches in cosine similarity
- Dynamic dimension caching for OpenAI service
- Fix stale docs (384 → 64-4096 dimensions)

### Advanced Bubbles Components
- **bubbles/viewport**: Replace manual detail scroll with native viewport (PageUp/Down, ScrollPercent indicator, mouse wheel, auto-resize)
- **bubbles/progress**: Visual progress bar for reindex operation

### Professional UI Features
- **Command Palette** (Ctrl+K): Fuzzy-searchable action menu from any screen
- **Status bar**: Persistent footer with screen name, position [N/M], filter, stats, version
- **Help screen** (?): Organized keyboard shortcuts by section
- **Centered modals**: Delete confirmation uses lipgloss.Place overlay
- **Toast messages**: Auto-dismissing ✓/⚠ feedback after actions
- **Dashboard sparkline**: 7-day activity chart (▁▂▅▇█▆▃)
- **Mouse support**: Scroll wheel in viewport, click foundation
- **Responsive layout**: Compact mode for small terminals (<60w or <20h)

### TUI Interactions
- Provider/model change detection with reindex warning + [x] to reindex
- Project filter (f key), delete (d), unarchive (u), obs→session (s)
- Vim G/gg keys, search history, dirty indicator, loading spinners
- Type color coding, health tab headers, compact logo, focus ring infrastructure
- Background-color selection indicator for menus and lists

## Files changed
- `go.mod`, `go.sum` — viewport, progress dependencies
- `internal/cli/cli.go` — mouse support
- `internal/embedding/service.go` — mutex, dynamic dims
- `internal/mcp/tools_cortex.go`, `tools_memory.go` — error logging
- `internal/store/sqlite/` — dimension warnings, Restore/Unarchive
- `internal/domain/interfaces.go` — docs fix
- `internal/tui/*` — model, update, view, store, styles, tests

## Test plan
- [x] `go build -tags cortex_vectors ./cmd/cortex`
- [x] All tests pass (TUI, embedding, MCP, sqlite)
- [x] Lint clean (staticcheck, unused)